### PR TITLE
Clean up forbid unsafe attributes everywhere

### DIFF
--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use core::fmt::Debug;
 
 /// Read from a byte slice.

--- a/codec/src/macros.rs
+++ b/codec/src/macros.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 /// A macro which defines an enum type.
 #[macro_export]
 macro_rules! enum_builder {

--- a/mctp_transport/src/header.rs
+++ b/mctp_transport/src/header.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use codec::enum_builder;
 use codec::{Codec, Reader, Writer};
 use spdmlib::common::SpdmTransportEncap;

--- a/pcidoe_transport/src/header.rs
+++ b/pcidoe_transport/src/header.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use codec::enum_builder;
 use codec::{Codec, Reader, Writer};
 use spdmlib::common::SpdmTransportEncap;

--- a/spdmlib/build.rs
+++ b/spdmlib/build.rs
@@ -71,8 +71,6 @@ macro_rules! TEMPLATE {
 // It is not intended for manual editing.
 // Please kindly configure via etc/config.json instead.
 
-#![forbid(unsafe_code)]
-
 /// This is used in SpdmVersionResponsePayload
 pub const MAX_SPDM_VERSION_COUNT: usize = {ver_cnt};
 

--- a/spdmlib/src/cmds/algorithm.rs
+++ b/spdmlib/src/cmds/algorithm.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::config;
 use crate::msgs::SpdmCodec;

--- a/spdmlib/src/cmds/capability.rs
+++ b/spdmlib/src/cmds/capability.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use codec::{Codec, Reader, Writer};

--- a/spdmlib/src/cmds/certificate.rs
+++ b/spdmlib/src/cmds/certificate.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::config;
 use crate::msgs::SpdmCodec;

--- a/spdmlib/src/cmds/challenge.rs
+++ b/spdmlib/src/cmds/challenge.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use crate::msgs::{

--- a/spdmlib/src/cmds/digest.rs
+++ b/spdmlib/src/cmds/digest.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use crate::msgs::{SpdmDigestStruct, SPDM_MAX_SLOT_NUMBER};

--- a/spdmlib/src/cmds/end_session.rs
+++ b/spdmlib/src/cmds/end_session.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use codec::{Codec, Reader, Writer};

--- a/spdmlib/src/cmds/error.rs
+++ b/spdmlib/src/cmds/error.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use codec::enum_builder;

--- a/spdmlib/src/cmds/finish.rs
+++ b/spdmlib/src/cmds/finish.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use crate::msgs::{

--- a/spdmlib/src/cmds/heartbeat.rs
+++ b/spdmlib/src/cmds/heartbeat.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use codec::{Codec, Reader, Writer};

--- a/spdmlib/src/cmds/key_exchange.rs
+++ b/spdmlib/src/cmds/key_exchange.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use crate::msgs::{

--- a/spdmlib/src/cmds/key_update.rs
+++ b/spdmlib/src/cmds/key_update.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use codec::enum_builder;

--- a/spdmlib/src/cmds/measurement.rs
+++ b/spdmlib/src/cmds/measurement.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use crate::msgs::{

--- a/spdmlib/src/cmds/mod.rs
+++ b/spdmlib/src/cmds/mod.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 // SPDM 1.0
 pub mod algorithm;
 pub mod capability;

--- a/spdmlib/src/cmds/psk_exchange.rs
+++ b/spdmlib/src/cmds/psk_exchange.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use crate::msgs::{

--- a/spdmlib/src/cmds/psk_finish.rs
+++ b/spdmlib/src/cmds/psk_finish.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::msgs::SpdmCodec;
 use crate::msgs::SpdmDigestStruct;

--- a/spdmlib/src/cmds/version.rs
+++ b/spdmlib/src/cmds/version.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::config;
 use crate::msgs::SpdmCodec;

--- a/spdmlib/src/common.rs
+++ b/spdmlib/src/common.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2020 Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
-#![forbid(unsafe_code)]
 
 use crate::config;
 use crate::crypto;

--- a/spdmlib/src/crypto/spdm_ring/asym_verify_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/asym_verify_impl.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
 use crate::crypto::{self, SpdmAsymVerify};
 use crate::error::SpdmResult;
 use crate::msgs::{SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmSignatureStruct};

--- a/spdmlib/src/error.rs
+++ b/spdmlib/src/error.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use core::fmt::{Debug, Formatter, Result};
 
 /// POSIX errno

--- a/spdmlib/src/msgs/algo.rs
+++ b/spdmlib/src/msgs/algo.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::config;
 use bytes::BytesMut;
 use codec::{enum_builder, Codec, Reader, Writer};

--- a/spdmlib/src/msgs/errors.rs
+++ b/spdmlib/src/msgs/errors.rs
@@ -2,6 +2,4 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::msgs::codec::{Codec, Reader};

--- a/spdmlib/src/msgs/header.rs
+++ b/spdmlib/src/msgs/header.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use codec::enum_builder;
 use codec::{Codec, Reader, Writer};
 

--- a/spdmlib/src/msgs/mod.rs
+++ b/spdmlib/src/msgs/mod.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 mod algo;
 mod header;
 mod opaque;

--- a/spdmlib/src/msgs/opaque.rs
+++ b/spdmlib/src/msgs/opaque.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::config;
 use crate::msgs::SpdmCodec;

--- a/spdmlib/src/msgs/spdm_codec.rs
+++ b/spdmlib/src/msgs/spdm_codec.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common;
 use crate::config;
 use crate::msgs::*;

--- a/spdmlib/src/requester/challenge_req.rs
+++ b/spdmlib/src/requester/challenge_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/context.rs
+++ b/spdmlib/src/requester/context.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common::{self, SpdmDeviceIo, SpdmTransportEncap};
 use crate::config;
 use crate::error::SpdmResult;

--- a/spdmlib/src/requester/end_session_req.rs
+++ b/spdmlib/src/requester/end_session_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/finish_req.rs
+++ b/spdmlib/src/requester/finish_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/get_capabilities_req.rs
+++ b/spdmlib/src/requester/get_capabilities_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/get_certificate_req.rs
+++ b/spdmlib/src/requester/get_certificate_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::crypto;
 use crate::error::SpdmResult;
 use crate::requester::*;

--- a/spdmlib/src/requester/get_digests_req.rs
+++ b/spdmlib/src/requester/get_digests_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/get_measurements_req.rs
+++ b/spdmlib/src/requester/get_measurements_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/get_version_req.rs
+++ b/spdmlib/src/requester/get_version_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/heartbeat_req.rs
+++ b/spdmlib/src/requester/heartbeat_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/key_exchange_req.rs
+++ b/spdmlib/src/requester/key_exchange_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/key_update_req.rs
+++ b/spdmlib/src/requester/key_update_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/mod.rs
+++ b/spdmlib/src/requester/mod.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 mod context;
 
 mod challenge_req;

--- a/spdmlib/src/requester/negotiate_algorithms_req.rs
+++ b/spdmlib/src/requester/negotiate_algorithms_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/psk_exchange_req.rs
+++ b/spdmlib/src/requester/psk_exchange_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use config::MAX_SPDM_PSK_CONTEXT_SIZE;
 
 use crate::error::SpdmResult;

--- a/spdmlib/src/requester/psk_finish_req.rs
+++ b/spdmlib/src/requester/psk_finish_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/responder/algorithm_rsp.rs
+++ b/spdmlib/src/responder/algorithm_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::crypto;
 use crate::responder::*;
 

--- a/spdmlib/src/responder/capability_rsp.rs
+++ b/spdmlib/src/responder/capability_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 impl<'a> ResponderContext<'a> {

--- a/spdmlib/src/responder/certificate_rsp.rs
+++ b/spdmlib/src/responder/certificate_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 impl<'a> ResponderContext<'a> {

--- a/spdmlib/src/responder/challenge_rsp.rs
+++ b/spdmlib/src/responder/challenge_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::crypto;
 use crate::responder::*;
 

--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::common::{self, SpdmDeviceIo, SpdmTransportEncap};
 use crate::config;
 use crate::error::SpdmResult;

--- a/spdmlib/src/responder/digest_rsp.rs
+++ b/spdmlib/src/responder/digest_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::crypto;
 use crate::responder::*;
 

--- a/spdmlib/src/responder/end_session_rsp.rs
+++ b/spdmlib/src/responder/end_session_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 impl<'a> ResponderContext<'a> {

--- a/spdmlib/src/responder/error_rsp.rs
+++ b/spdmlib/src/responder/error_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 impl<'a> ResponderContext<'a> {

--- a/spdmlib/src/responder/finish_rsp.rs
+++ b/spdmlib/src/responder/finish_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 use crate::common::ManagedBuffer;

--- a/spdmlib/src/responder/heartbeat_rsp.rs
+++ b/spdmlib/src/responder/heartbeat_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 impl<'a> ResponderContext<'a> {

--- a/spdmlib/src/responder/key_exchange_rsp.rs
+++ b/spdmlib/src/responder/key_exchange_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 use crate::common::ManagedBuffer;

--- a/spdmlib/src/responder/key_update_rsp.rs
+++ b/spdmlib/src/responder/key_update_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 impl<'a> ResponderContext<'a> {

--- a/spdmlib/src/responder/measurement_rsp.rs
+++ b/spdmlib/src/responder/measurement_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 impl<'a> ResponderContext<'a> {

--- a/spdmlib/src/responder/mod.rs
+++ b/spdmlib/src/responder/mod.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 mod context;
 
 mod algorithm_rsp;

--- a/spdmlib/src/responder/psk_exchange_rsp.rs
+++ b/spdmlib/src/responder/psk_exchange_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use config::MAX_SPDM_PSK_CONTEXT_SIZE;
 
 use crate::responder::*;

--- a/spdmlib/src/responder/psk_finish_rsp.rs
+++ b/spdmlib/src/responder/psk_finish_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 use crate::common::ManagedBuffer;

--- a/spdmlib/src/responder/version_rsp.rs
+++ b/spdmlib/src/responder/version_rsp.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::responder::*;
 
 impl<'a> ResponderContext<'a> {

--- a/spdmlib/src/session.rs
+++ b/spdmlib/src/session.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2020 Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
-#![forbid(unsafe_code)]
 
 use crate::crypto;
 use crate::msgs::*;

--- a/test/spdm-emu/src/socket_io_transport.rs
+++ b/test/spdm-emu/src/socket_io_transport.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use crate::spdm_emu::*;
 use std::net::TcpStream;
 

--- a/test/spdm-emu/src/spdm_emu.rs
+++ b/test/spdm-emu/src/spdm_emu.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 use std::net::TcpStream;
 use std::io::{Write, Read};
 

--- a/test/spdm-emu/src/tcp_transport.rs
+++ b/test/spdm-emu/src/tcp_transport.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![forbid(unsafe_code)]
-
 // use codec::{Reader, Codec, Writer};
 use std::net::TcpStream;
 use std::io::{Write, Read};


### PR DESCRIPTION
`#![forbid(unsafe_code)]` crate attributes are added to crate roots to
statically guarantee that only Safe Rust is applied. They are enabled at the
crate level thus all (sub-)mods enforcements are not necessary.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>