### PR TITLE
Decouple io from requester

### DIFF
--- a/spdmlib/src/common.rs
+++ b/spdmlib/src/common.rs
@@ -108,6 +108,15 @@ impl<'a> SpdmContext<'a> {
         self.runtime_info = SpdmRuntimeInfo::default();
     }
 
+    pub fn get_immutable_session_via_id(&self, session_id: u32) -> Option<&SpdmSession> {
+        for session in self.session.iter() {
+            if session.get_session_id() == session_id {
+                return Some(session);
+            }
+        }
+        None
+    }
+
     pub fn get_session_via_id(&mut self, session_id: u32) -> Option<&mut SpdmSession> {
         for session in self.session.iter_mut() {
             if session.get_session_id() == session_id {
@@ -122,7 +131,7 @@ impl<'a> SpdmContext<'a> {
     }
 
     pub fn calc_req_transcript_data(
-        &mut self,
+        &self,
         use_psk: bool,
         message_k: &ManagedBuffer,
         message_f: Option<&ManagedBuffer>,
@@ -199,7 +208,7 @@ impl<'a> SpdmContext<'a> {
     }
 
     pub fn calc_req_transcript_hash(
-        &mut self,
+        &self,
         use_psk: bool,
         message_k: &ManagedBuffer,
         message_f: Option<&ManagedBuffer>,

--- a/spdmlib/src/requester/context.rs
+++ b/spdmlib/src/requester/context.rs
@@ -176,7 +176,6 @@ impl<'a> RequesterContext<'a> {
         self.decode_secured_message(session_id, &transport_buffer[..used], receive_buffer)
     }
 
-
     pub fn decode_secured_message(
         &mut self,
         session_id: u32,

--- a/spdmlib/src/requester/end_session_req.rs
+++ b/spdmlib/src/requester/end_session_req.rs
@@ -9,7 +9,16 @@ impl<'a> RequesterContext<'a> {
     pub fn send_receive_spdm_end_session(&mut self, session_id: u32) -> SpdmResult {
         info!("send spdm end_session\n");
         let mut send_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let mut writer = Writer::init(&mut send_buffer);
+        let used = self.encode_spdm_end_session(&mut send_buffer);
+        self.send_secured_message(session_id, &send_buffer[..used])?;
+
+        let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        self.handle_spdm_end_session_response(session_id, &receive_buffer[..used])
+    }
+
+    pub fn encode_spdm_end_session(&mut self, buf: &mut [u8]) -> usize {
+        let mut writer = Writer::init(buf);
 
         let request = SpdmMessage {
             header: SpdmMessageHeader {
@@ -21,15 +30,15 @@ impl<'a> RequesterContext<'a> {
             }),
         };
         request.spdm_encode(&mut self.common, &mut writer);
-        let used = writer.used();
+        writer.used()
+    }
 
-        self.send_secured_message(session_id, &send_buffer[..used])?;
-
-        // Receive
-        let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_secured_message(session_id, &mut receive_buffer)?;
-
-        let mut reader = Reader::init(&receive_buffer[..used]);
+    pub fn handle_spdm_end_session_response(
+        &mut self,
+        session_id: u32,
+        receive_buffer: &[u8],
+    ) -> SpdmResult {
+        let mut reader = Reader::init(receive_buffer);
         match SpdmMessageHeader::read(&mut reader) {
             Some(message_header) => match message_header.request_response_code {
                 SpdmResponseResponseCode::SpdmResponseEndSessionAck => {

--- a/spdmlib/src/requester/finish_req.rs
+++ b/spdmlib/src/requester/finish_req.rs
@@ -59,7 +59,10 @@ impl<'a> RequesterContext<'a> {
             .append_message(&buf[..temp_used])
             .ok_or(spdm_err!(ENOMEM))?;
 
-        let session = self.common.get_immutable_session_via_id(session_id).unwrap();
+        let session = self
+            .common
+            .get_immutable_session_via_id(session_id)
+            .unwrap();
         let message_k = &session.runtime_info.message_k;
 
         let transcript_data =
@@ -105,8 +108,10 @@ impl<'a> RequesterContext<'a> {
                         debug!("!!! finish rsp : {:02x?}\n", finish_rsp);
 
                         if in_clear_text {
-
-                            let session = self.common.get_immutable_session_via_id(session_id).unwrap();
+                            let session = self
+                                .common
+                                .get_immutable_session_via_id(session_id)
+                                .unwrap();
                             let message_k = &session.runtime_info.message_k;
 
                             // verify HMAC with finished_key
@@ -147,7 +152,10 @@ impl<'a> RequesterContext<'a> {
                             session.runtime_info.message_f = message_f;
                         }
 
-                        let session = self.common.get_immutable_session_via_id(session_id).unwrap();
+                        let session = self
+                            .common
+                            .get_immutable_session_via_id(session_id)
+                            .unwrap();
                         let message_k = &session.runtime_info.message_k;
                         // generate the data secret
                         let th2 = self.common.calc_req_transcript_hash(

--- a/spdmlib/src/requester/get_capabilities_req.rs
+++ b/spdmlib/src/requester/get_capabilities_req.rs
@@ -8,7 +8,16 @@ use crate::requester::*;
 impl<'a> RequesterContext<'a> {
     pub fn send_receive_spdm_capability(&mut self) -> SpdmResult {
         let mut send_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let mut writer = Writer::init(&mut send_buffer);
+        let send_used = self.encode_spdm_capability(&mut send_buffer);
+        self.send_message(&send_buffer[..send_used])?;
+
+        let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let used = self.receive_message(&mut receive_buffer)?;
+        self.handle_spdm_capability_response(&send_buffer[..send_used], &receive_buffer[..used])
+    }
+
+    pub fn encode_spdm_capability(&mut self, buf: &mut [u8]) -> usize {
+        let mut writer = Writer::init(buf);
         let request = SpdmMessage {
             header: SpdmMessageHeader {
                 version: SpdmVersion::SpdmVersion11,
@@ -22,25 +31,15 @@ impl<'a> RequesterContext<'a> {
             ),
         };
         request.spdm_encode(&mut self.common, &mut writer);
-        let used = writer.used();
+        writer.used()
+    }
 
-        self.send_message(&send_buffer[..used])?;
-
-        if self
-            .common
-            .runtime_info
-            .message_a
-            .append_message(&send_buffer[..used])
-            .is_none()
-        {
-            return spdm_result_err!(ENOMEM);
-        }
-
-        // Receive
-        let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
-
-        let mut reader = Reader::init(&receive_buffer[..used]);
+    pub fn handle_spdm_capability_response(
+        &mut self,
+        send_buffer: &[u8],
+        receive_buffer: &[u8],
+    ) -> SpdmResult {
+        let mut reader = Reader::init(receive_buffer);
         match SpdmMessageHeader::read(&mut reader) {
             Some(message_header) => match message_header.request_response_code {
                 SpdmResponseResponseCode::SpdmResponseCapabilities => {
@@ -56,17 +55,13 @@ impl<'a> RequesterContext<'a> {
                         self.common.negotiate_info.rsp_ct_exponent_sel = capabilities.ct_exponent;
                         self.common.negotiate_info.rsp_capabilities_sel = capabilities.flags;
 
-                        if self
-                            .common
-                            .runtime_info
-                            .message_a
+                        let message_a = &mut self.common.runtime_info.message_a;
+                        message_a
+                            .append_message(send_buffer)
+                            .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))?;
+                        message_a
                             .append_message(&receive_buffer[..used])
-                            .is_none()
-                        {
-                            return spdm_result_err!(ENOMEM);
-                        }
-
-                        Ok(())
+                            .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))
                     } else {
                         error!("!!! capabilities : fail !!!\n");
                         spdm_result_err!(EFAULT)

--- a/spdmlib/src/requester/get_version_req.rs
+++ b/spdmlib/src/requester/get_version_req.rs
@@ -8,7 +8,16 @@ use crate::requester::*;
 impl<'a> RequesterContext<'a> {
     pub fn send_receive_spdm_version(&mut self) -> SpdmResult {
         let mut send_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let mut writer = Writer::init(&mut send_buffer);
+        let send_used = self.encode_spdm_version(&mut send_buffer);
+        self.send_message(&send_buffer[..send_used])?;
+
+        let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let used = self.receive_message(&mut receive_buffer)?;
+        self.handle_spdm_version_response(&send_buffer[..send_used], &receive_buffer[..used])
+    }
+
+    pub fn encode_spdm_version(&mut self, buf: &mut [u8]) -> usize {
+        let mut writer = Writer::init(buf);
         let request = SpdmMessage {
             header: SpdmMessageHeader {
                 version: SpdmVersion::SpdmVersion10,
@@ -17,29 +26,15 @@ impl<'a> RequesterContext<'a> {
             payload: SpdmMessagePayload::SpdmGetVersionRequest(SpdmGetVersionRequestPayload {}),
         };
         request.spdm_encode(&mut self.common, &mut writer);
-        let used = writer.used();
+        writer.used()
+    }
 
-        self.send_message(&send_buffer[..used])?;
-
-        // clear cache data
-        self.common.reset_runtime_info();
-
-        // append message_a
-        if self
-            .common
-            .runtime_info
-            .message_a
-            .append_message(&send_buffer[..used])
-            .is_none()
-        {
-            return spdm_result_err!(ENOMEM);
-        }
-
-        // Receive
-        let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
-
-        let mut reader = Reader::init(&receive_buffer[..used]);
+    pub fn handle_spdm_version_response(
+        &mut self,
+        send_buffer: &[u8],
+        receive_buffer: &[u8],
+    ) -> SpdmResult {
+        let mut reader = Reader::init(receive_buffer);
         match SpdmMessageHeader::read(&mut reader) {
             Some(message_header) => match message_header.request_response_code {
                 SpdmResponseResponseCode::SpdmResponseVersion => {
@@ -49,17 +44,16 @@ impl<'a> RequesterContext<'a> {
                     if let Some(version) = version {
                         debug!("!!! version : {:02x?}\n", version);
 
-                        if self
-                            .common
-                            .runtime_info
-                            .message_a
-                            .append_message(&receive_buffer[..used])
-                            .is_none()
-                        {
-                            return spdm_result_err!(ENOMEM);
-                        }
+                        // clear cache data
+                        self.common.reset_runtime_info();
 
-                        Ok(())
+                        let message_a = &mut self.common.runtime_info.message_a;
+                        message_a
+                            .append_message(send_buffer)
+                            .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))?;
+                        message_a
+                            .append_message(&receive_buffer[..used])
+                            .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))
                     } else {
                         error!("!!! version : fail !!!\n");
                         spdm_result_err!(EFAULT)

--- a/spdmlib/src/requester/key_exchange_req.rs
+++ b/spdmlib/src/requester/key_exchange_req.rs
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
+extern crate alloc;
+use alloc::boxed::Box;
+
 use crate::error::SpdmResult;
 use crate::requester::*;
 

--- a/spdmlib/src/requester/key_update_req.rs
+++ b/spdmlib/src/requester/key_update_req.rs
@@ -14,8 +14,25 @@ impl<'a> RequesterContext<'a> {
     ) -> SpdmResult {
         info!("send spdm key_update\n");
         let mut send_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let mut writer = Writer::init(&mut send_buffer);
+        let used = self.encode_spdm_key_update_op(key_update_operation, tag, &mut send_buffer);
+        self.send_secured_message(session_id, &send_buffer[..used])?;
 
+        let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        self.handle_spdm_key_update_op_response(
+            session_id,
+            key_update_operation,
+            &receive_buffer[..used],
+        )
+    }
+
+    pub fn encode_spdm_key_update_op(
+        &mut self,
+        key_update_operation: SpdmKeyUpdateOperation,
+        tag: u8,
+        buf: &mut [u8],
+    ) -> usize {
+        let mut writer = Writer::init(buf);
         let request = SpdmMessage {
             header: SpdmMessageHeader {
                 version: SpdmVersion::SpdmVersion11,
@@ -27,10 +44,15 @@ impl<'a> RequesterContext<'a> {
             }),
         };
         request.spdm_encode(&mut self.common, &mut writer);
-        let used = writer.used();
+        writer.used()
+    }
 
-        self.send_secured_message(session_id, &send_buffer[..used])?;
-
+    pub fn handle_spdm_key_update_op_response(
+        &mut self,
+        session_id: u32,
+        key_update_operation: SpdmKeyUpdateOperation,
+        receive_buffer: &[u8],
+    ) -> SpdmResult {
         // update key
         let session = self.common.get_session_via_id(session_id).unwrap();
         let update_requester = key_update_operation == SpdmKeyUpdateOperation::SpdmUpdateSingleKey
@@ -38,11 +60,7 @@ impl<'a> RequesterContext<'a> {
         let update_responder = key_update_operation == SpdmKeyUpdateOperation::SpdmUpdateAllKeys;
         session.create_data_secret_update(update_requester, update_responder)?;
 
-        // Receive
-        let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_secured_message(session_id, &mut receive_buffer)?;
-
-        let mut reader = Reader::init(&receive_buffer[..used]);
+        let mut reader = Reader::init(receive_buffer);
         match SpdmMessageHeader::read(&mut reader) {
             Some(message_header) => match message_header.request_response_code {
                 SpdmResponseResponseCode::SpdmResponseKeyUpdateAck => {

--- a/spdmlib/src/requester/psk_finish_req.rs
+++ b/spdmlib/src/requester/psk_finish_req.rs
@@ -99,7 +99,7 @@ impl<'a> RequesterContext<'a> {
                         let message_k = &session.runtime_info.message_k; // generate the data secret
                         let th2 = self.common.calc_req_transcript_hash(
                             true,
-                            &message_k,
+                            message_k,
                             Some(&message_f),
                         )?;
                         debug!("!!! th2 : {:02x?}\n", th2.as_ref());

--- a/spdmlib/src/session.rs
+++ b/spdmlib/src/session.rs
@@ -129,7 +129,7 @@ impl SpdmSession {
         self.application_secret = SpdmSessionAppliationSecret::default();
     }
 
-    pub fn get_session_id(&mut self) -> u32 {
+    pub fn get_session_id(&self) -> u32 {
         self.session_id
     }
 
@@ -547,7 +547,7 @@ impl SpdmSession {
     }
 
     pub fn verify_hmac_with_response_finished_key(
-        &mut self,
+        &self,
         message: &[u8],
         hmac: &SpdmDigestStruct,
     ) -> SpdmResult {


### PR DESCRIPTION
This PR separates the majority of requester logic for encoding messages and handling message from the blocking send and receive calls made by the `SpdmDeviceIo` implementations. This allows usage of this logic in asynchronous contexts. 

It's the first half of the required code for implementing #170. The responder is up next.

I put the changes made to the `RequesterContext` and each message into separate commits for easier reviewing. I'm happy to squash if desired.