### PR TITLE
spdmlib: Zeroize secret after use

### DIFF
--- a/spdmlib/Cargo.toml
+++ b/spdmlib/Cargo.toml
@@ -19,6 +19,8 @@ conquer-once = { version = "0.3.2", default-features = false }
 ring = { git="https://github.com/jyao1/ring", branch="uefi_support",  optional = true }
 webpki = { git="https://github.com/jyao1/webpki", branch="uefi_support", default-features = false, features = ["alloc"], optional = true}
 untrusted = { version = "0.7.1", optional = true }
+zeroize = { version = "1.5.0", features = ["zeroize_derive"]}
+
 
 [target.'cfg(any(target_os = "uefi", target_os = "none"))'.dependencies]
 uefi_time = {git = "https://github.com/jyao1/rust-uefi-time.git", optional = true}

--- a/spdmlib/src/common/error.rs
+++ b/spdmlib/src/common/error.rs
@@ -7,7 +7,7 @@ use core::fmt::{Debug, Formatter, Result};
 /// POSIX errno
 #[repr(u32)]
 #[allow(dead_code)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SpdmErrorNum {
     EUNDEF = 0,
     EPERM = 1,
@@ -73,7 +73,7 @@ impl SpdmError {
     }
 
     pub fn code(&self) -> i32 {
-        -(self.num as u32 as i32)
+        -(self.num.clone() as u32 as i32)
     }
 }
 

--- a/spdmlib/src/common/key_schedule.rs
+++ b/spdmlib/src/common/key_schedule.rs
@@ -6,6 +6,8 @@ use super::algo::*;
 use crate::config::MAX_SPDM_MESSAGE_BUFFER_SIZE;
 use crate::crypto;
 use codec::{Codec, Writer};
+extern crate alloc;
+use alloc::boxed::Box;
 
 const SALT_0: [u8; SPDM_MAX_HASH_SIZE] = [0u8; SPDM_MAX_HASH_SIZE];
 const ZERO_FILLED: [u8; SPDM_MAX_HASH_SIZE] = [0u8; SPDM_MAX_HASH_SIZE];
@@ -21,7 +23,7 @@ const BIN_STR8_LABEL: &[u8] = b"exp master";
 const BIN_STR9_LABEL: &[u8] = b"traffic upd";
 const SPDM_VERSION_VALUE: &[u8; 8] = b"spdm1.1 ";
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct SpdmKeySchedule;
 
 impl Default for SpdmKeySchedule {
@@ -136,7 +138,7 @@ impl SpdmKeySchedule {
         let encrypt_key = SpdmAeadKeyStruct {
             data_size: res.data_size,
             data: {
-                let mut k = [0u8; SPDM_MAX_AEAD_KEY_SIZE];
+                let mut k = Box::new([0u8; SPDM_MAX_AEAD_KEY_SIZE]);
                 k[0..res.data_size as usize].copy_from_slice(&res.data[0..res.data_size as usize]);
                 k
             },
@@ -154,7 +156,7 @@ impl SpdmKeySchedule {
         let iv = SpdmAeadIvStruct {
             data_size: res.data_size,
             data: {
-                let mut k = [0u8; SPDM_MAX_AEAD_IV_SIZE];
+                let mut k = Box::new([0u8; SPDM_MAX_AEAD_IV_SIZE]);
                 k[0..res.data_size as usize].copy_from_slice(&res.data[0..res.data_size as usize]);
                 k
             },

--- a/spdmlib/src/common/opaque.rs
+++ b/spdmlib/src/common/opaque.rs
@@ -9,7 +9,7 @@ use codec::{Codec, Reader, Writer};
 
 //pub const SPDM_MAX_OPAQUE_SIZE : usize = 1024;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct SpdmOpaqueStruct {
     pub data_size: u16,
     pub data: [u8; config::MAX_SPDM_OPAQUE_SIZE],

--- a/spdmlib/src/crypto/crypto_callbacks.rs
+++ b/spdmlib/src/crypto/crypto_callbacks.rs
@@ -12,12 +12,12 @@ use crate::common::algo::{
     SpdmDheFinalKeyStruct, SpdmDigestStruct, SpdmSignatureStruct,
 };
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SpdmHash {
     pub hash_all_cb: fn(base_hash_algo: SpdmBaseHashAlgo, data: &[u8]) -> Option<SpdmDigestStruct>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SpdmHmac {
     pub hmac_cb:
         fn(base_hash_algo: SpdmBaseHashAlgo, key: &[u8], data: &[u8]) -> Option<SpdmDigestStruct>,
@@ -50,14 +50,14 @@ type DecryptCb = fn(
     plain_text: &mut [u8],
 ) -> SpdmResult<usize>;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SpdmAead {
     pub encrypt_cb: EncryptCb,
 
     pub decrypt_cb: DecryptCb,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SpdmAsymSign {
     pub sign_cb: fn(
         base_hash_algo: SpdmBaseHashAlgo,
@@ -66,7 +66,7 @@ pub struct SpdmAsymSign {
     ) -> Option<SpdmSignatureStruct>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SpdmAsymVerify {
     pub verify_cb: fn(
         base_hash_algo: SpdmBaseHashAlgo,
@@ -77,7 +77,7 @@ pub struct SpdmAsymVerify {
     ) -> SpdmResult,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SpdmHkdf {
     pub hkdf_expand_cb: fn(
         hash_algo: SpdmBaseHashAlgo,
@@ -89,7 +89,7 @@ pub struct SpdmHkdf {
 
 type GetCertFromCertChainCb = fn(cert_chain: &[u8], index: isize) -> SpdmResult<(usize, usize)>;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SpdmCertOperation {
     pub get_cert_from_cert_chain_cb: GetCertFromCertChainCb,
 
@@ -99,7 +99,7 @@ pub struct SpdmCertOperation {
 type GenerateKeyPairCb =
     fn(dhe_algo: SpdmDheAlgo) -> Option<(SpdmDheExchangeStruct, Box<dyn SpdmDheKeyExchange>)>;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SpdmDhe {
     pub generate_key_pair_cb: GenerateKeyPairCb,
 }
@@ -111,7 +111,7 @@ pub trait SpdmDheKeyExchange {
     ) -> Option<SpdmDheFinalKeyStruct>;
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SpdmCryptoRandom {
     pub get_random_cb: fn(data: &mut [u8]) -> SpdmResult<usize>,
 }

--- a/spdmlib/src/crypto/mod.rs
+++ b/spdmlib/src/crypto/mod.rs
@@ -44,7 +44,10 @@ pub mod hash {
     }
 
     pub fn hash_all(base_hash_algo: SpdmBaseHashAlgo, data: &[u8]) -> Option<SpdmDigestStruct> {
-        (CRYPTO_HASH.try_get_or_init(|| DEFAULT).ok()?.hash_all_cb)(base_hash_algo, data)
+        (CRYPTO_HASH
+            .try_get_or_init(|| DEFAULT.clone())
+            .ok()?
+            .hash_all_cb)(base_hash_algo, data)
     }
 }
 
@@ -79,7 +82,10 @@ pub mod hmac {
         key: &[u8],
         data: &[u8],
     ) -> Option<SpdmDigestStruct> {
-        (CRYPTO_HMAC.try_get_or_init(|| DEFAULT).ok()?.hmac_cb)(base_hash_algo, key, data)
+        (CRYPTO_HMAC
+            .try_get_or_init(|| DEFAULT.clone())
+            .ok()?
+            .hmac_cb)(base_hash_algo, key, data)
     }
 
     pub fn hmac_verify(
@@ -89,7 +95,7 @@ pub mod hmac {
         hmac: &SpdmDigestStruct,
     ) -> SpdmResult {
         (CRYPTO_HMAC
-            .try_get_or_init(|| DEFAULT)
+            .try_get_or_init(|| DEFAULT.clone())
             .map_err(|_| spdm_err!(EFAULT))?
             .hmac_verify_cb)(base_hash_algo, key, data, hmac)
     }
@@ -116,11 +122,10 @@ pub mod asym_sign {
         base_asym_algo: SpdmBaseAsymAlgo,
         data: &[u8],
     ) -> Option<SpdmSignatureStruct> {
-        (CRYPTO_ASYM_SIGN.try_get_or_init(|| DEFAULT).ok()?.sign_cb)(
-            base_hash_algo,
-            base_asym_algo,
-            data,
-        )
+        (CRYPTO_ASYM_SIGN
+            .try_get_or_init(|| DEFAULT.clone())
+            .ok()?
+            .sign_cb)(base_hash_algo, base_asym_algo, data)
     }
 }
 
@@ -155,7 +160,7 @@ pub mod asym_verify {
         signature: &SpdmSignatureStruct,
     ) -> SpdmResult {
         (CRYPTO_ASYM_VERIFY
-            .try_get_or_init(|| DEFAULT)
+            .try_get_or_init(|| DEFAULT.clone())
             .map_err(|_| spdm_err!(EFAULT))?
             .verify_cb)(
             base_hash_algo,
@@ -194,7 +199,7 @@ pub mod dhe {
         dhe_algo: SpdmDheAlgo,
     ) -> Option<(SpdmDheExchangeStruct, Box<dyn SpdmDheKeyExchange>)> {
         (CRYPTO_DHE
-            .try_get_or_init(|| DEFAULT)
+            .try_get_or_init(|| DEFAULT.clone())
             .ok()?
             .generate_key_pair_cb)(dhe_algo)
     }
@@ -222,14 +227,14 @@ pub mod cert_operation {
 
     pub fn get_cert_from_cert_chain(cert_chain: &[u8], index: isize) -> SpdmResult<(usize, usize)> {
         (CRYPTO_CERT_OPERATION
-            .try_get_or_init(|| DEFAULT)
+            .try_get_or_init(|| DEFAULT.clone())
             .map_err(|_| spdm_err!(EFAULT))?
             .get_cert_from_cert_chain_cb)(cert_chain, index)
     }
 
     pub fn verify_cert_chain(cert_chain: &[u8]) -> SpdmResult {
         (CRYPTO_CERT_OPERATION
-            .try_get_or_init(|| DEFAULT)
+            .try_get_or_init(|| DEFAULT.clone())
             .map_err(|_| spdm_err!(EFAULT))?
             .verify_cert_chain_cb)(cert_chain)
     }
@@ -262,9 +267,10 @@ pub mod hkdf {
         info: &[u8],
         out_size: u16,
     ) -> Option<SpdmDigestStruct> {
-        (CRYPTO_HKDF.try_get_or_init(|| DEFAULT).ok()?.hkdf_expand_cb)(
-            hash_algo, pk, info, out_size,
-        )
+        (CRYPTO_HKDF
+            .try_get_or_init(|| DEFAULT.clone())
+            .ok()?
+            .hkdf_expand_cb)(hash_algo, pk, info, out_size)
     }
 }
 
@@ -311,7 +317,7 @@ pub mod aead {
         cipher_text: &mut [u8],
     ) -> SpdmResult<(usize, usize)> {
         (CRYPTO_AEAD
-            .try_get_or_init(|| DEFAULT)
+            .try_get_or_init(|| DEFAULT.clone())
             .map_err(|_| spdm_err!(EFAULT))?
             .encrypt_cb)(aead_algo, key, iv, aad, plain_text, tag, cipher_text)
     }
@@ -326,7 +332,7 @@ pub mod aead {
         plain_text: &mut [u8],
     ) -> SpdmResult<usize> {
         (CRYPTO_AEAD
-            .try_get_or_init(|| DEFAULT)
+            .try_get_or_init(|| DEFAULT.clone())
             .map_err(|_| spdm_err!(EFAULT))?
             .decrypt_cb)(aead_algo, key, iv, aad, cipher_text, tag, plain_text)
     }
@@ -351,7 +357,7 @@ pub mod rand {
 
     pub fn get_random(data: &mut [u8]) -> SpdmResult<usize> {
         (CRYPTO_RAND
-            .try_get_or_init(|| DEFAULT)
+            .try_get_or_init(|| DEFAULT.clone())
             .map_err(|_| spdm_err!(EFAULT))?
             .get_random_cb)(data)
     }
@@ -373,32 +379,32 @@ mod tests {
     }
     #[test]
     fn test_case0_hmac_register() {
-        let state = hmac::register(HMAC_TEST);
+        let state = hmac::register(HMAC_TEST.clone());
         assert_eq!(state, true);
     }
     #[test]
     fn test_case0_hash_register() {
-        let state = hash::register(spdm_ring::hash_impl::DEFAULT);
+        let state = hash::register(spdm_ring::hash_impl::DEFAULT.clone());
         assert_eq!(state, true);
     }
     #[test]
     fn test_case0_asym_verify_register() {
-        let state = asym_verify::register(spdm_ring::asym_verify_impl::DEFAULT);
+        let state = asym_verify::register(spdm_ring::asym_verify_impl::DEFAULT.clone());
         assert_eq!(state, true);
     }
     #[test]
     fn test_case0_dhe_register() {
-        let state = dhe::register(spdm_ring::dhe_impl::DEFAULT);
+        let state = dhe::register(spdm_ring::dhe_impl::DEFAULT.clone());
         assert_eq!(state, true);
     }
     #[test]
     fn test_case0_hkdf_register() {
-        let state = hkdf::register(spdm_ring::hkdf_impl::DEFAULT);
+        let state = hkdf::register(spdm_ring::hkdf_impl::DEFAULT.clone());
         assert_eq!(state, true);
     }
     #[test]
     fn test_case0_aead_register() {
-        let state = aead::register(spdm_ring::aead_impl::DEFAULT);
+        let state = aead::register(spdm_ring::aead_impl::DEFAULT.clone());
         match state {
             false => {
                 use super::CRYPTO_AEAD;
@@ -412,7 +418,7 @@ mod tests {
     }
     #[test]
     fn test_case0_rand_register() {
-        let state = rand::register(DEFAULT_TEST);
+        let state = rand::register(DEFAULT_TEST.clone());
         assert_eq!(state, true);
     }
 }

--- a/spdmlib/src/message/algorithm.rs
+++ b/spdmlib/src/message/algorithm.rs
@@ -4,12 +4,13 @@
 
 pub use crate::common;
 pub use crate::common::algo::*;
+use crate::common::gen_array_clone;
 pub use crate::common::spdm_codec::*;
 use crate::config;
 
 use codec::{Codec, Reader, Writer};
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmNegotiateAlgorithmsRequestPayload {
     pub measurement_specification: SpdmMeasurementSpecification,
     pub base_asym_algo: SpdmBaseAsymAlgo,
@@ -79,7 +80,8 @@ impl SpdmCodec for SpdmNegotiateAlgorithmsRequestPayload {
 
         u16::read(r)?; // reserved3
 
-        let mut alg_struct = [SpdmAlgStruct::default(); config::MAX_SPDM_ALG_STRUCT_COUNT];
+        let mut alg_struct =
+            gen_array_clone(SpdmAlgStruct::default(), config::MAX_SPDM_ALG_STRUCT_COUNT);
         for algo in alg_struct.iter_mut().take(alg_struct_count as usize) {
             *algo = SpdmAlgStruct::read(r)?;
         }
@@ -106,7 +108,7 @@ impl SpdmCodec for SpdmNegotiateAlgorithmsRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmAlgorithmsResponsePayload {
     pub measurement_specification_sel: SpdmMeasurementSpecification,
     pub measurement_hash_algo: SpdmMeasurementHashAlgo,
@@ -180,7 +182,8 @@ impl SpdmCodec for SpdmAlgorithmsResponsePayload {
 
         u16::read(r)?; // reserved3
 
-        let mut alg_struct = [SpdmAlgStruct::default(); config::MAX_SPDM_ALG_STRUCT_COUNT];
+        let mut alg_struct =
+            gen_array_clone(SpdmAlgStruct::default(), config::MAX_SPDM_ALG_STRUCT_COUNT);
         for algo in alg_struct.iter_mut().take(alg_struct_count as usize) {
             *algo = SpdmAlgStruct::read(r)?;
         }
@@ -219,12 +222,15 @@ mod tests {
             base_asym_algo: SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
             base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_256,
             alg_struct_count: 4,
-            alg_struct: [SpdmAlgStruct {
-                alg_type: SpdmAlgType::SpdmAlgTypeDHE,
-                alg_fixed_count: 2,
-                alg_supported: SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::FFDHE_2048),
-                alg_ext_count: 0,
-            }; config::MAX_SPDM_ALG_STRUCT_COUNT],
+            alg_struct: gen_array_clone(
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeDHE,
+                    alg_fixed_count: 2,
+                    alg_supported: SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::FFDHE_2048),
+                    alg_ext_count: 0,
+                },
+                config::MAX_SPDM_ALG_STRUCT_COUNT,
+            ),
         };
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let my_spdm_device_io = &mut MySpdmDeviceIo;
@@ -271,7 +277,10 @@ mod tests {
             base_asym_algo: SpdmBaseAsymAlgo::empty(),
             base_hash_algo: SpdmBaseHashAlgo::empty(),
             alg_struct_count: 0,
-            alg_struct: [SpdmAlgStruct::default(); config::MAX_SPDM_ALG_STRUCT_COUNT],
+            alg_struct: gen_array_clone(
+                SpdmAlgStruct::default(),
+                config::MAX_SPDM_ALG_STRUCT_COUNT,
+            ),
         };
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
@@ -300,7 +309,10 @@ mod tests {
             base_asym_algo: SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
             base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_256,
             alg_struct_count: 0,
-            alg_struct: [SpdmAlgStruct::default(); config::MAX_SPDM_ALG_STRUCT_COUNT],
+            alg_struct: gen_array_clone(
+                SpdmAlgStruct::default(),
+                config::MAX_SPDM_ALG_STRUCT_COUNT,
+            ),
         };
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
@@ -326,12 +338,15 @@ mod tests {
             base_asym_sel: SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
             base_hash_sel: SpdmBaseHashAlgo::TPM_ALG_SHA_256,
             alg_struct_count: 4,
-            alg_struct: [SpdmAlgStruct {
-                alg_type: SpdmAlgType::SpdmAlgTypeDHE,
-                alg_fixed_count: 2,
-                alg_supported: SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::FFDHE_2048),
-                alg_ext_count: 0,
-            }; config::MAX_SPDM_ALG_STRUCT_COUNT],
+            alg_struct: gen_array_clone(
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeDHE,
+                    alg_fixed_count: 2,
+                    alg_supported: SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::FFDHE_2048),
+                    alg_ext_count: 0,
+                },
+                config::MAX_SPDM_ALG_STRUCT_COUNT,
+            ),
         };
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
@@ -384,7 +399,10 @@ mod tests {
             base_asym_sel: SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
             base_hash_sel: SpdmBaseHashAlgo::TPM_ALG_SHA_256,
             alg_struct_count: 0,
-            alg_struct: [SpdmAlgStruct::default(); config::MAX_SPDM_ALG_STRUCT_COUNT],
+            alg_struct: gen_array_clone(
+                SpdmAlgStruct::default(),
+                config::MAX_SPDM_ALG_STRUCT_COUNT,
+            ),
         };
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
@@ -411,7 +429,10 @@ mod tests {
             base_asym_sel: SpdmBaseAsymAlgo::empty(),
             base_hash_sel: SpdmBaseHashAlgo::empty(),
             alg_struct_count: 0,
-            alg_struct: [SpdmAlgStruct::default(); config::MAX_SPDM_ALG_STRUCT_COUNT],
+            alg_struct: gen_array_clone(
+                SpdmAlgStruct::default(),
+                config::MAX_SPDM_ALG_STRUCT_COUNT,
+            ),
         };
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};

--- a/spdmlib/src/message/capability.rs
+++ b/spdmlib/src/message/capability.rs
@@ -37,7 +37,7 @@ impl Codec for SpdmRequestCapabilityFlags {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmGetCapabilitiesRequestPayload {
     pub ct_exponent: u8,
     pub flags: SpdmRequestCapabilityFlags,
@@ -107,7 +107,7 @@ impl Codec for SpdmResponseCapabilityFlags {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmCapabilitiesResponsePayload {
     pub ct_exponent: u8,
     pub flags: SpdmResponseCapabilityFlags,

--- a/spdmlib/src/message/certificate.rs
+++ b/spdmlib/src/message/certificate.rs
@@ -7,7 +7,7 @@ use crate::common::spdm_codec::SpdmCodec;
 use crate::config;
 use codec::{Codec, Reader, Writer};
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmGetCertificateRequestPayload {
     pub slot_id: u8,
     pub offset: u16,
@@ -39,7 +39,7 @@ impl SpdmCodec for SpdmGetCertificateRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct SpdmCertificateResponsePayload {
     pub slot_id: u8,
     pub portion_length: u16,

--- a/spdmlib/src/message/challenge.rs
+++ b/spdmlib/src/message/challenge.rs
@@ -10,7 +10,7 @@ use crate::common::opaque::SpdmOpaqueStruct;
 use crate::common::spdm_codec::SpdmCodec;
 use codec::{Codec, Reader, Writer};
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmChallengeRequestPayload {
     pub slot_id: u8,
     pub measurement_summary_hash_type: SpdmMeasurementSummaryHashType,
@@ -47,7 +47,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmChallengeAuthResponsePayload {
     pub slot_id: u8,
     pub slot_mask: u8,
@@ -150,14 +150,14 @@ mod tests {
             challenge_auth_attribute: SpdmChallengeAuthAttribute::BASIC_MUT_AUTH_REQ,
             cert_chain_hash: SpdmDigestStruct {
                 data_size: 64,
-                data: [0xAAu8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([0xAAu8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
             nonce: SpdmNonceStruct {
                 data: [100u8; common::algo::SPDM_NONCE_SIZE],
             },
             measurement_summary_hash: SpdmDigestStruct {
                 data_size: 64,
-                data: [0x55u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([0x55u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
             opaque: SpdmOpaqueStruct {
                 data_size: 64,
@@ -217,7 +217,7 @@ mod tests {
             challenge_auth_attribute: SpdmChallengeAuthAttribute::BASIC_MUT_AUTH_REQ,
             cert_chain_hash: SpdmDigestStruct {
                 data_size: 64,
-                data: [0xAAu8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([0xAAu8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
             nonce: SpdmNonceStruct {
                 data: [100u8; common::algo::SPDM_NONCE_SIZE],

--- a/spdmlib/src/message/digest.rs
+++ b/spdmlib/src/message/digest.rs
@@ -4,10 +4,11 @@
 
 use crate::common;
 use crate::common::algo::{SpdmDigestStruct, SPDM_MAX_SLOT_NUMBER};
+use crate::common::gen_array_clone;
 use crate::common::spdm_codec::SpdmCodec;
 use codec::{Codec, Reader, Writer};
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmGetDigestsRequestPayload {}
 
 impl SpdmCodec for SpdmGetDigestsRequestPayload {
@@ -27,7 +28,7 @@ impl SpdmCodec for SpdmGetDigestsRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmDigestsResponsePayload {
     pub slot_mask: u8,
     pub slot_count: u8,
@@ -69,7 +70,7 @@ impl SpdmCodec for SpdmDigestsResponsePayload {
             }
         }
 
-        let mut digests = [SpdmDigestStruct::default(); SPDM_MAX_SLOT_NUMBER];
+        let mut digests = gen_array_clone(SpdmDigestStruct::default(), SPDM_MAX_SLOT_NUMBER);
         for digest in digests.iter_mut().take(slot_count as usize) {
             *digest = SpdmDigestStruct::spdm_read(context, r)?;
         }
@@ -94,10 +95,13 @@ mod tests {
         let mut value = SpdmDigestsResponsePayload {
             slot_mask: 0b11111111,
             slot_count: 8,
-            digests: [SpdmDigestStruct {
-                data_size: 64,
-                data: [0u8; common::algo::SPDM_MAX_HASH_SIZE],
-            }; SPDM_MAX_SLOT_NUMBER],
+            digests: gen_array_clone(
+                SpdmDigestStruct {
+                    data_size: 64,
+                    data: Box::new([0u8; common::algo::SPDM_MAX_HASH_SIZE]),
+                },
+                SPDM_MAX_SLOT_NUMBER,
+            ),
         };
         for i in 0..8 {
             for j in 0..64 {
@@ -135,7 +139,7 @@ mod tests {
         let mut value = SpdmDigestsResponsePayload::default();
         value.slot_mask = 0b00000000;
         value.slot_count = 0;
-        value.digests = [SpdmDigestStruct::default(); SPDM_MAX_SLOT_NUMBER];
+        value.digests = gen_array_clone(SpdmDigestStruct::default(), SPDM_MAX_SLOT_NUMBER);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let my_spdm_device_io = &mut MySpdmDeviceIo;
         let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);
@@ -149,7 +153,7 @@ mod tests {
         let mut value = SpdmDigestsResponsePayload::default();
         value.slot_mask = 0b00011111;
         value.slot_count = 3;
-        value.digests = [SpdmDigestStruct::default(); SPDM_MAX_SLOT_NUMBER];
+        value.digests = gen_array_clone(SpdmDigestStruct::default(), SPDM_MAX_SLOT_NUMBER);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let my_spdm_device_io = &mut MySpdmDeviceIo;
         let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);

--- a/spdmlib/src/message/end_session.rs
+++ b/spdmlib/src/message/end_session.rs
@@ -25,7 +25,7 @@ impl Codec for SpdmEndSessionRequestAttributes {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct SpdmEndSessionRequestPayload {
     pub end_session_request_attributes: SpdmEndSessionRequestAttributes,
 }
@@ -49,7 +49,7 @@ impl SpdmCodec for SpdmEndSessionRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmEndSessionResponsePayload {}
 
 impl SpdmCodec for SpdmEndSessionResponsePayload {

--- a/spdmlib/src/message/error.rs
+++ b/spdmlib/src/message/error.rs
@@ -28,7 +28,7 @@ enum_builder! {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct SpdmErrorResponseNoneExtData {}
 
 impl SpdmCodec for SpdmErrorResponseNoneExtData {
@@ -42,7 +42,7 @@ impl SpdmCodec for SpdmErrorResponseNoneExtData {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct SpdmErrorResponseNotReadyExtData {
     pub rdt_exponent: u8,
     pub request_code: u8,
@@ -76,7 +76,7 @@ impl SpdmCodec for SpdmErrorResponseNotReadyExtData {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct SpdmErrorResponseVendorExtData {
     pub data_size: u8,
     pub data: [u8; 32],
@@ -113,7 +113,7 @@ impl SpdmCodec for SpdmErrorResponseVendorExtData {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SpdmErrorResponseExtData {
     SpdmErrorExtDataNone(SpdmErrorResponseNoneExtData),
     SpdmErrorExtDataNotReady(SpdmErrorResponseNotReadyExtData),
@@ -125,7 +125,7 @@ impl Default for SpdmErrorResponseExtData {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmErrorResponsePayload {
     pub error_code: SpdmErrorCode,
     pub error_data: u8,

--- a/spdmlib/src/message/finish.rs
+++ b/spdmlib/src/message/finish.rs
@@ -27,7 +27,7 @@ impl Codec for SpdmFinishRequestAttributes {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmFinishRequestPayload {
     pub finish_request_attributes: SpdmFinishRequestAttributes,
     pub req_slot_id: u8,
@@ -69,7 +69,7 @@ impl SpdmCodec for SpdmFinishRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmFinishResponsePayload {
     pub verify_data: SpdmDigestStruct,
 }
@@ -134,7 +134,7 @@ mod tests {
             },
             verify_data: SpdmDigestStruct {
                 data_size: 64,
-                data: [0x5au8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([0x5au8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
         };
 
@@ -176,7 +176,7 @@ mod tests {
             },
             verify_data: SpdmDigestStruct {
                 data_size: 64,
-                data: [0x5au8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([0x5au8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
         };
 
@@ -208,7 +208,7 @@ mod tests {
         let value = SpdmFinishResponsePayload {
             verify_data: SpdmDigestStruct {
                 data_size: 64,
-                data: [100u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([100u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
         };
 
@@ -239,7 +239,7 @@ mod tests {
         let value = SpdmFinishResponsePayload {
             verify_data: SpdmDigestStruct {
                 data_size: 64,
-                data: [100u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([100u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
         };
 

--- a/spdmlib/src/message/heartbeat.rs
+++ b/spdmlib/src/message/heartbeat.rs
@@ -6,7 +6,7 @@ use crate::common;
 use crate::common::spdm_codec::SpdmCodec;
 use codec::{Codec, Reader, Writer};
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmHeartbeatRequestPayload {}
 
 impl SpdmCodec for SpdmHeartbeatRequestPayload {
@@ -26,7 +26,7 @@ impl SpdmCodec for SpdmHeartbeatRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmHeartbeatResponsePayload {}
 
 impl SpdmCodec for SpdmHeartbeatResponsePayload {

--- a/spdmlib/src/message/key_exchange.rs
+++ b/spdmlib/src/message/key_exchange.rs
@@ -11,7 +11,7 @@ use crate::common::opaque::SpdmOpaqueStruct;
 use crate::common::spdm_codec::SpdmCodec;
 use codec::{Codec, Reader, Writer};
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmKeyExchangeRequestPayload {
     pub measurement_summary_hash_type: SpdmMeasurementSummaryHashType,
     pub slot_id: u8,
@@ -78,7 +78,7 @@ impl Codec for SpdmKeyExchangeMutAuthAttributes {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmKeyExchangeResponsePayload {
     pub heartbeat_period: u8,
     pub rsp_session_id: u16,
@@ -236,7 +236,7 @@ mod tests {
             },
             measurement_summary_hash: SpdmDigestStruct {
                 data_size: 64u16,
-                data: [0x11u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([0x11u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
             opaque: SpdmOpaqueStruct {
                 data_size: 64u16,
@@ -248,7 +248,7 @@ mod tests {
             },
             verify_data: SpdmDigestStruct {
                 data_size: 64u16,
-                data: [0x33u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([0x33u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
         };
 
@@ -327,7 +327,7 @@ mod tests {
             },
             verify_data: SpdmDigestStruct {
                 data_size: 64u16,
-                data: [0x33u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([0x33u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
         };
 

--- a/spdmlib/src/message/key_update.rs
+++ b/spdmlib/src/message/key_update.rs
@@ -17,7 +17,7 @@ enum_builder! {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmKeyUpdateRequestPayload {
     pub key_update_operation: SpdmKeyUpdateOperation,
     pub tag: u8,
@@ -43,7 +43,7 @@ impl SpdmCodec for SpdmKeyUpdateRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmKeyUpdateResponsePayload {
     pub key_update_operation: SpdmKeyUpdateOperation,
     pub tag: u8,

--- a/spdmlib/src/message/measurement.rs
+++ b/spdmlib/src/message/measurement.rs
@@ -37,7 +37,7 @@ enum_builder! {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmGetMeasurementsRequestPayload {
     pub measurement_attributes: SpdmMeasurementeAttributes,
     pub measurement_operation: SpdmMeasurementOperation,
@@ -86,7 +86,7 @@ impl SpdmCodec for SpdmGetMeasurementsRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmMeasurementsResponsePayload {
     pub number_of_measurement: u8,
     pub slot_id: u8,
@@ -243,7 +243,8 @@ mod tests {
             slot_id: 100u8,
             measurement_record: SpdmMeasurementRecordStructure {
                 number_of_blocks: 5,
-                record: [common::algo::SpdmMeasurementBlockStructure {
+                record: gen_array_clone(
+                    common::algo::SpdmMeasurementBlockStructure {
                     index: 100u8,
                     measurement_specification: common::algo::SpdmMeasurementSpecification::DMTF,
                     measurement_size: 67u16,
@@ -254,7 +255,7 @@ mod tests {
                         value_size: 64u16,
                         value: [100u8; MAX_SPDM_MEASUREMENT_VALUE_LEN],
                     },
-                }; MAX_SPDM_MEASUREMENT_BLOCK_COUNT],
+                },MAX_SPDM_MEASUREMENT_BLOCK_COUNT),
             },
             nonce: SpdmNonceStruct {
                 data: [100u8; common::algo::SPDM_NONCE_SIZE],

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -100,7 +100,7 @@ enum_builder! {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmMessageHeader {
     pub version: SpdmVersion,
     pub request_response_code: SpdmRequestResponseCode,
@@ -482,7 +482,9 @@ impl SpdmCodec for SpdmMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::gen_array_clone;
     use crate::common::*;
+    use crate::config;
     use crate::config::*;
     use crate::testlib::*;
 
@@ -518,10 +520,13 @@ mod tests {
             },
             payload: SpdmMessagePayload::SpdmVersionResponse(SpdmVersionResponsePayload {
                 version_number_entry_count: 0x02,
-                versions: [SpdmVersionStruct {
-                    update: 100,
-                    version: SpdmVersion::SpdmVersion11,
-                }; crate::config::MAX_SPDM_VERSION_COUNT],
+                versions: gen_array_clone(
+                    SpdmVersionStruct {
+                        update: 100,
+                        version: SpdmVersion::SpdmVersion11,
+                    },
+                    config::MAX_SPDM_VERSION_COUNT,
+                ),
             }),
         };
 
@@ -612,12 +617,15 @@ mod tests {
                     base_asym_algo: SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
                     base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_256,
                     alg_struct_count: 4,
-                    alg_struct: [SpdmAlgStruct {
-                        alg_type: SpdmAlgType::SpdmAlgTypeDHE,
-                        alg_fixed_count: 2,
-                        alg_supported: SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::FFDHE_2048),
-                        alg_ext_count: 0,
-                    }; crate::config::MAX_SPDM_ALG_STRUCT_COUNT],
+                    alg_struct: gen_array_clone(
+                        SpdmAlgStruct {
+                            alg_type: SpdmAlgType::SpdmAlgTypeDHE,
+                            alg_fixed_count: 2,
+                            alg_supported: SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::FFDHE_2048),
+                            alg_ext_count: 0,
+                        },
+                        config::MAX_SPDM_ALG_STRUCT_COUNT,
+                    ),
                 },
             ),
         };
@@ -665,12 +673,15 @@ mod tests {
                 base_asym_sel: SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
                 base_hash_sel: SpdmBaseHashAlgo::TPM_ALG_SHA_256,
                 alg_struct_count: 4,
-                alg_struct: [SpdmAlgStruct {
-                    alg_type: SpdmAlgType::SpdmAlgTypeDHE,
-                    alg_fixed_count: 2,
-                    alg_supported: SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::FFDHE_2048),
-                    alg_ext_count: 0,
-                }; MAX_SPDM_ALG_STRUCT_COUNT],
+                alg_struct: gen_array_clone(
+                    SpdmAlgStruct {
+                        alg_type: SpdmAlgType::SpdmAlgTypeDHE,
+                        alg_fixed_count: 2,
+                        alg_supported: SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::FFDHE_2048),
+                        alg_ext_count: 0,
+                    },
+                    MAX_SPDM_ALG_STRUCT_COUNT,
+                ),
             }),
         };
         let context = new_context(my_spdm_device_io, pcidoe_transport_encap);
@@ -785,14 +796,14 @@ mod tests {
                     challenge_auth_attribute: SpdmChallengeAuthAttribute::BASIC_MUT_AUTH_REQ,
                     cert_chain_hash: SpdmDigestStruct {
                         data_size: 64,
-                        data: [0xAAu8; SPDM_MAX_HASH_SIZE],
+                        data: Box::new([0xAAu8; SPDM_MAX_HASH_SIZE]),
                     },
                     nonce: SpdmNonceStruct {
                         data: [100u8; SPDM_NONCE_SIZE],
                     },
                     measurement_summary_hash: SpdmDigestStruct {
                         data_size: 64,
-                        data: [0x55u8; SPDM_MAX_HASH_SIZE],
+                        data: Box::new([0x55u8; SPDM_MAX_HASH_SIZE]),
                     },
                     opaque: SpdmOpaqueStruct {
                         data_size: 64,
@@ -898,18 +909,21 @@ mod tests {
                     slot_id: 100u8,
                     measurement_record: SpdmMeasurementRecordStructure {
                         number_of_blocks: 5,
-                        record: [SpdmMeasurementBlockStructure {
-                            index: 100u8,
-                            measurement_specification: SpdmMeasurementSpecification::DMTF,
-                            measurement_size: 67u16,
-                            measurement: SpdmDmtfMeasurementStructure {
-                                r#type: SpdmDmtfMeasurementType::SpdmDmtfMeasurementRom,
-                                representation:
-                                    SpdmDmtfMeasurementRepresentation::SpdmDmtfMeasurementDigest,
-                                value_size: 64u16,
-                                value: [100u8; MAX_SPDM_MEASUREMENT_VALUE_LEN],
+                        record: gen_array_clone(
+                            SpdmMeasurementBlockStructure {
+                                index: 100u8,
+                                measurement_specification: SpdmMeasurementSpecification::DMTF,
+                                measurement_size: 67u16,
+                                measurement: SpdmDmtfMeasurementStructure {
+                                    r#type: SpdmDmtfMeasurementType::SpdmDmtfMeasurementRom,
+                                    representation:
+                                        SpdmDmtfMeasurementRepresentation::SpdmDmtfMeasurementDigest,
+                                    value_size: 64u16,
+                                    value: [100u8; MAX_SPDM_MEASUREMENT_VALUE_LEN],
+                                },
                             },
-                        }; MAX_SPDM_MEASUREMENT_BLOCK_COUNT],
+                            MAX_SPDM_MEASUREMENT_BLOCK_COUNT,
+                        ),
                     },
                     nonce: SpdmNonceStruct {
                         data: [100u8; SPDM_NONCE_SIZE],
@@ -1053,7 +1067,7 @@ mod tests {
                 },
                 verify_data: SpdmDigestStruct {
                     data_size: 64,
-                    data: [0x5au8; SPDM_MAX_HASH_SIZE],
+                    data: Box::new([0x5au8; SPDM_MAX_HASH_SIZE]),
                 },
             }),
         };
@@ -1094,7 +1108,7 @@ mod tests {
             payload: SpdmMessagePayload::SpdmFinishResponse(SpdmFinishResponsePayload {
                 verify_data: SpdmDigestStruct {
                     data_size: 64,
-                    data: [100u8; SPDM_MAX_HASH_SIZE],
+                    data: Box::new([100u8; SPDM_MAX_HASH_SIZE]),
                 },
             }),
         };
@@ -1177,7 +1191,7 @@ mod tests {
                 rsp_session_id: 0xaa55u16,
                 measurement_summary_hash: SpdmDigestStruct {
                     data_size: 64,
-                    data: [100u8; SPDM_MAX_HASH_SIZE],
+                    data: Box::new([100u8; SPDM_MAX_HASH_SIZE]),
                 },
                 psk_context: SpdmPskContextStruct {
                     data_size: 64,
@@ -1189,7 +1203,7 @@ mod tests {
                 },
                 verify_data: SpdmDigestStruct {
                     data_size: 64,
-                    data: [100u8; SPDM_MAX_HASH_SIZE],
+                    data: Box::new([100u8; SPDM_MAX_HASH_SIZE]),
                 },
             }),
         };
@@ -1231,7 +1245,7 @@ mod tests {
             payload: SpdmMessagePayload::SpdmPskFinishRequest(SpdmPskFinishRequestPayload {
                 verify_data: SpdmDigestStruct {
                     data_size: 64,
-                    data: [100u8; SPDM_MAX_HASH_SIZE],
+                    data: Box::new([100u8; SPDM_MAX_HASH_SIZE]),
                 },
             }),
         };
@@ -1513,10 +1527,13 @@ mod tests {
             payload: SpdmMessagePayload::SpdmDigestsResponse(SpdmDigestsResponsePayload {
                 slot_mask: 0b11111111,
                 slot_count: 8,
-                digests: [SpdmDigestStruct {
-                    data_size: 64,
-                    data: [100u8; SPDM_MAX_HASH_SIZE],
-                }; SPDM_MAX_SLOT_NUMBER],
+                digests: gen_array_clone(
+                    SpdmDigestStruct {
+                        data_size: 64,
+                        data: Box::new([100u8; SPDM_MAX_HASH_SIZE]),
+                    },
+                    SPDM_MAX_SLOT_NUMBER,
+                ),
             }),
         };
         let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);

--- a/spdmlib/src/message/psk_exchange.rs
+++ b/spdmlib/src/message/psk_exchange.rs
@@ -10,7 +10,7 @@ use crate::common::opaque::SpdmOpaqueStruct;
 use crate::common::spdm_codec::SpdmCodec;
 use codec::{Codec, Reader, Writer};
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmPskExchangeRequestPayload {
     pub measurement_summary_hash_type: SpdmMeasurementSummaryHashType,
     pub req_session_id: u16,
@@ -90,7 +90,7 @@ impl SpdmCodec for SpdmPskExchangeRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmPskExchangeResponsePayload {
     pub heartbeat_period: u8,
     pub rsp_session_id: u16,
@@ -284,7 +284,7 @@ mod tests {
             rsp_session_id: 0xaa55u16,
             measurement_summary_hash: SpdmDigestStruct {
                 data_size: 64,
-                data: [100u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([100u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
             psk_context: SpdmPskContextStruct {
                 data_size: 64,
@@ -296,7 +296,7 @@ mod tests {
             },
             verify_data: SpdmDigestStruct {
                 data_size: 64,
-                data: [100u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([100u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
         };
 
@@ -354,7 +354,7 @@ mod tests {
             rsp_session_id: 0xaa55u16,
             measurement_summary_hash: SpdmDigestStruct {
                 data_size: 64,
-                data: [100u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([100u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
             psk_context: SpdmPskContextStruct {
                 data_size: 0,
@@ -366,7 +366,7 @@ mod tests {
             },
             verify_data: SpdmDigestStruct {
                 data_size: 64,
-                data: [100u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([100u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
         };
 

--- a/spdmlib/src/message/psk_finish.rs
+++ b/spdmlib/src/message/psk_finish.rs
@@ -7,7 +7,7 @@ use crate::common::algo::SpdmDigestStruct;
 use crate::common::spdm_codec::SpdmCodec;
 use codec::{Codec, Reader, Writer};
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmPskFinishRequestPayload {
     pub verify_data: SpdmDigestStruct,
 }
@@ -31,7 +31,7 @@ impl SpdmCodec for SpdmPskFinishRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmPskFinishResponsePayload {}
 
 impl SpdmCodec for SpdmPskFinishResponsePayload {
@@ -63,7 +63,7 @@ mod tests {
         let value = SpdmPskFinishRequestPayload {
             verify_data: SpdmDigestStruct {
                 data_size: 64,
-                data: [100u8; common::algo::SPDM_MAX_HASH_SIZE],
+                data: Box::new([100u8; common::algo::SPDM_MAX_HASH_SIZE]),
             },
         };
 

--- a/spdmlib/src/message/vendor.rs
+++ b/spdmlib/src/message/vendor.rs
@@ -40,7 +40,7 @@ impl RegistryOrStandardsBodyID {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct VendorIDStruct {
     pub len: u8,
     pub vendor_id: [u8; config::MAX_SPDM_VENDOR_DEFINED_VENDOR_ID_LEN],
@@ -69,7 +69,7 @@ impl Codec for VendorIDStruct {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct ReqPayloadStruct {
     pub req_length: u16,
     pub vendor_defined_req_payload: [u8; config::MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE],
@@ -102,7 +102,7 @@ impl Codec for ReqPayloadStruct {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct ResPayloadStruct {
     pub res_length: u16,
     pub vendor_defined_res_payload: [u8; config::MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE],
@@ -136,7 +136,7 @@ impl Codec for ResPayloadStruct {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct SpdmVendorDefinedRequestPayload {
     pub standard_id: RegistryOrStandardsBodyID,
     pub vendor_id: VendorIDStruct,
@@ -170,7 +170,7 @@ impl SpdmCodec for SpdmVendorDefinedRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct SpdmVendorDefinedResponsePayload {
     pub standard_id: RegistryOrStandardsBodyID,
     pub vendor_id: VendorIDStruct,

--- a/spdmlib/src/message/version.rs
+++ b/spdmlib/src/message/version.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use super::SpdmVersion;
-use crate::common;
 use crate::common::spdm_codec::SpdmCodec;
+use crate::common::{self, gen_array_clone};
 use crate::config;
 use codec::{Codec, Reader, Writer};
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmGetVersionRequestPayload {}
 
 impl SpdmCodec for SpdmGetVersionRequestPayload {
@@ -28,7 +28,7 @@ impl SpdmCodec for SpdmGetVersionRequestPayload {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmVersionStruct {
     pub update: u8,
     pub version: SpdmVersion,
@@ -46,7 +46,7 @@ impl Codec for SpdmVersionStruct {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SpdmVersionResponsePayload {
     pub version_number_entry_count: u8,
     pub versions: [SpdmVersionStruct; config::MAX_SPDM_VERSION_COUNT],
@@ -79,10 +79,13 @@ impl SpdmCodec for SpdmVersionResponsePayload {
         u8::read(r)?; // reserved
         let version_number_entry_count = u8::read(r)?;
 
-        let mut versions = [SpdmVersionStruct {
-            update: 0,
-            version: SpdmVersion::SpdmVersion10,
-        }; config::MAX_SPDM_VERSION_COUNT];
+        let mut versions = gen_array_clone(
+            SpdmVersionStruct {
+                update: 0,
+                version: SpdmVersion::SpdmVersion10,
+            },
+            config::MAX_SPDM_VERSION_COUNT,
+        );
         for version in versions
             .iter_mut()
             .take(version_number_entry_count as usize)
@@ -135,10 +138,13 @@ mod tests {
         let mut writer = Writer::init(u8_slice);
         let value = SpdmVersionResponsePayload {
             version_number_entry_count: 2u8,
-            versions: [SpdmVersionStruct {
-                update: 100u8,
-                version: SpdmVersion::SpdmVersion10,
-            }; config::MAX_SPDM_VERSION_COUNT],
+            versions: gen_array_clone(
+                SpdmVersionStruct {
+                    update: 100u8,
+                    version: SpdmVersion::SpdmVersion10,
+                },
+                config::MAX_SPDM_VERSION_COUNT,
+            ),
         };
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};

--- a/spdmlib/src/requester/challenge_req.rs
+++ b/spdmlib/src/requester/challenge_req.rs
@@ -134,8 +134,8 @@ mod tests_requester {
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
-        crypto::rand::register(DEFAULT_TEST);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
+        crypto::rand::register(DEFAULT_TEST.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,

--- a/spdmlib/src/requester/context.rs
+++ b/spdmlib/src/requester/context.rs
@@ -154,7 +154,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,
@@ -213,7 +213,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,
@@ -226,7 +226,7 @@ mod tests_requester {
             common::algo::SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         let rsp_session_id = 0xffu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
-        responder.common.session = [SpdmSession::new(); 4];
+        responder.common.session = gen_array_clone(SpdmSession::new(), 4);
         responder.common.session[0].setup(session_id).unwrap();
         responder.common.session[0].set_crypto_param(
             common::algo::SpdmBaseHashAlgo::TPM_ALG_SHA_384,
@@ -251,7 +251,7 @@ mod tests_requester {
             common::algo::SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         let rsp_session_id = 0xffu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
-        requester.common.session = [SpdmSession::new(); 4];
+        requester.common.session = gen_array_clone(SpdmSession::new(), 4);
         requester.common.session[0].setup(session_id).unwrap();
         requester.common.session[0].set_crypto_param(
             common::algo::SpdmBaseHashAlgo::TPM_ALG_SHA_384,

--- a/spdmlib/src/requester/end_session_req.rs
+++ b/spdmlib/src/requester/end_session_req.rs
@@ -80,7 +80,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,
@@ -92,7 +92,7 @@ mod tests_requester {
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         let rsp_session_id = 0xffu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
-        responder.common.session = [SpdmSession::new(); 4];
+        responder.common.session = gen_array_clone(SpdmSession::new(), 4);
         responder.common.session[0].setup(session_id).unwrap();
         responder.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
@@ -116,7 +116,7 @@ mod tests_requester {
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         let rsp_session_id = 0xffu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
-        requester.common.session = [SpdmSession::new(); 4];
+        requester.common.session = gen_array_clone(SpdmSession::new(), 4);
         requester.common.session[0].setup(session_id).unwrap();
         requester.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,

--- a/spdmlib/src/requester/get_capabilities_req.rs
+++ b/spdmlib/src/requester/get_capabilities_req.rs
@@ -90,7 +90,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,

--- a/spdmlib/src/requester/get_certificate_req.rs
+++ b/spdmlib/src/requester/get_certificate_req.rs
@@ -125,7 +125,7 @@ impl<'a> RequesterContext<'a> {
 
     pub fn verify_spdm_certificate_chain(&mut self) -> SpdmResult {
         // verify
-        if let Some(peer_cert_chain_data) = self.common.provision_info.peer_cert_chain_data {
+        if let Some(peer_cert_chain_data) = &self.common.provision_info.peer_cert_chain_data {
             //
             // TBD: Verify cert chain
             //
@@ -212,7 +212,7 @@ mod tests_requester {
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,

--- a/spdmlib/src/requester/get_digests_req.rs
+++ b/spdmlib/src/requester/get_digests_req.rs
@@ -80,7 +80,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,

--- a/spdmlib/src/requester/get_measurements_req.rs
+++ b/spdmlib/src/requester/get_measurements_req.rs
@@ -251,7 +251,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,

--- a/spdmlib/src/requester/get_version_req.rs
+++ b/spdmlib/src/requester/get_version_req.rs
@@ -82,7 +82,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,

--- a/spdmlib/src/requester/heartbeat_req.rs
+++ b/spdmlib/src/requester/heartbeat_req.rs
@@ -70,7 +70,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,
@@ -82,7 +82,7 @@ mod tests_requester {
         let rsp_session_id = 0x11u16;
         let session_id = (0x11u32 << 16) + rsp_session_id as u32;
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
-        responder.common.session = [SpdmSession::new(); 4];
+        responder.common.session = gen_array_clone(SpdmSession::new(), 4);
         responder.common.session[0].setup(session_id).unwrap();
         responder.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
@@ -106,7 +106,7 @@ mod tests_requester {
         let rsp_session_id = 0x11u16;
         let session_id = (0x11u32 << 16) + rsp_session_id as u32;
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
-        requester.common.session = [SpdmSession::new(); 4];
+        requester.common.session = gen_array_clone(SpdmSession::new(), 4);
         requester.common.session[0].setup(session_id).unwrap();
         requester.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,

--- a/spdmlib/src/requester/key_exchange_req.rs
+++ b/spdmlib/src/requester/key_exchange_req.rs
@@ -185,7 +185,7 @@ impl<'a> RequesterContext<'a> {
                             key_schedule_algo,
                         );
                         session.set_transport_param(sequence_number_count, max_random_count);
-                        session.set_dhe_secret(&final_key);
+                        session.set_dhe_secret(final_key);
                         session.generate_handshake_secret(&th1).unwrap();
 
                         // verify HMAC with finished_key
@@ -246,7 +246,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let message_m = &[
             0x11, 0xe0, 0x00, 0x00, 0x11, 0x60, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/spdmlib/src/requester/key_update_req.rs
+++ b/spdmlib/src/requester/key_update_req.rs
@@ -119,7 +119,6 @@ mod tests_requester {
     use crate::common::session::SpdmSession;
     use crate::testlib::*;
     use crate::{crypto, responder};
-
     #[test]
     fn test_case0_send_receive_spdm_key_update() {
         let (rsp_config_info, rsp_provision_info) = create_info();
@@ -129,7 +128,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,
@@ -141,7 +140,7 @@ mod tests_requester {
         let rsp_session_id = 0xFFFEu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
-        responder.common.session = [SpdmSession::new(); 4];
+        responder.common.session = gen_array_clone(SpdmSession::new(), 4);
         responder.common.session[0].setup(session_id).unwrap();
         responder.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
@@ -165,7 +164,7 @@ mod tests_requester {
         let rsp_session_id = 0xFFFEu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
-        requester.common.session = [SpdmSession::new(); 4];
+        requester.common.session = gen_array_clone(SpdmSession::new(), 4);
         requester.common.session[0].setup(session_id).unwrap();
         requester.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,

--- a/spdmlib/src/requester/negotiate_algorithms_req.rs
+++ b/spdmlib/src/requester/negotiate_algorithms_req.rs
@@ -92,14 +92,16 @@ impl<'a> RequesterContext<'a> {
                             .iter()
                             .take(algorithms.alg_struct_count as usize)
                         {
-                            match alg.alg_supported {
-                                SpdmAlg::SpdmAlgoDhe(v) => self.common.negotiate_info.dhe_sel = v,
-                                SpdmAlg::SpdmAlgoAead(v) => self.common.negotiate_info.aead_sel = v,
+                            match &alg.alg_supported {
+                                SpdmAlg::SpdmAlgoDhe(v) => self.common.negotiate_info.dhe_sel = *v,
+                                SpdmAlg::SpdmAlgoAead(v) => {
+                                    self.common.negotiate_info.aead_sel = *v
+                                }
                                 SpdmAlg::SpdmAlgoReqAsym(v) => {
-                                    self.common.negotiate_info.req_asym_sel = v
+                                    self.common.negotiate_info.req_asym_sel = *v
                                 }
                                 SpdmAlg::SpdmAlgoKeySchedule(v) => {
-                                    self.common.negotiate_info.key_schedule_sel = v
+                                    self.common.negotiate_info.key_schedule_sel = *v
                                 }
                                 SpdmAlg::SpdmAlgoUnknown(_v) => {}
                             }
@@ -138,7 +140,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = responder::ResponderContext::new(
             &mut device_io_responder,

--- a/spdmlib/src/requester/vendor_req.rs
+++ b/spdmlib/src/requester/vendor_req.rs
@@ -74,7 +74,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = ResponderContext::new(
             &mut device_io_responder,

--- a/spdmlib/src/responder/capability_rsp.rs
+++ b/spdmlib/src/responder/capability_rsp.rs
@@ -80,7 +80,7 @@ mod tests_responder {
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         let mut context = responder::ResponderContext::new(
             &mut socket_io_transport,
             pcidoe_transport_encap,

--- a/spdmlib/src/responder/certificate_rsp.rs
+++ b/spdmlib/src/responder/certificate_rsp.rs
@@ -19,7 +19,7 @@ impl<'a> ResponderContext<'a> {
 
         let get_certificate =
             SpdmGetCertificateRequestPayload::spdm_read(&mut self.common, &mut reader);
-        if let Some(get_certificate) = get_certificate {
+        if let Some(get_certificate) = &get_certificate {
             debug!("!!! get_certificate : {:02x?}\n", get_certificate);
         } else {
             error!("!!! get_certificate : fail !!!\n");
@@ -41,7 +41,7 @@ impl<'a> ResponderContext<'a> {
         let get_certificate = get_certificate.unwrap();
         let slot_id = get_certificate.slot_id;
 
-        let my_cert_chain = self.common.provision_info.my_cert_chain.unwrap();
+        let my_cert_chain = self.common.provision_info.my_cert_chain.as_ref().unwrap();
 
         let mut length = get_certificate.length;
         if length > config::MAX_SPDM_CERT_PORTION_LEN as u16 {
@@ -100,7 +100,7 @@ mod tests_responder {
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         let mut context = responder::ResponderContext::new(
             &mut socket_io_transport,
             pcidoe_transport_encap,

--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -114,6 +114,7 @@ impl<'a> ResponderContext<'a> {
         info!("receive_message!\n");
 
         let mut transport_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+
         let used = self.common.device_io.receive(receive_buffer)?;
 
         let (used, secured_message) = self
@@ -279,6 +280,7 @@ impl<'a> ResponderContext<'a> {
 #[cfg(test)]
 mod tests_responder {
     use super::*;
+    use crate::common::gen_array_clone;
     use crate::common::session::*;
     use crate::message::SpdmMessageHeader;
     use crate::testlib::*;
@@ -291,7 +293,7 @@ mod tests_responder {
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut context = responder::ResponderContext::new(
             &mut socket_io_transport,
@@ -303,7 +305,7 @@ mod tests_responder {
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         let rsp_session_id = 0xffu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
-        context.common.session = [SpdmSession::new(); 4];
+        context.common.session = gen_array_clone(SpdmSession::new(), 4);
         context.common.session[0].setup(session_id).unwrap();
         context.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
@@ -339,7 +341,7 @@ mod tests_responder {
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         let mut context = responder::ResponderContext::new(
             &mut socket_io_transport,
             pcidoe_transport_encap,
@@ -382,7 +384,7 @@ mod tests_responder {
         shared_buffer.set_buffer(receive_buffer);
 
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         let mut context = responder::ResponderContext::new(
             &mut socket_io_transport,
             pcidoe_transport_encap,
@@ -421,7 +423,7 @@ mod tests_responder {
         let rsp_session_id = 0xFFFEu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
-        context.common.session = [SpdmSession::new(); 4];
+        context.common.session = gen_array_clone(SpdmSession::new(), 4);
         context.common.session[0].setup(session_id).unwrap();
         context.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
@@ -450,7 +452,7 @@ mod tests_responder {
             provision_info,
         );
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
@@ -459,7 +461,7 @@ mod tests_responder {
 
         let rsp_session_id = 0xFFFEu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
-        context.common.session = [SpdmSession::new(); 4];
+        context.common.session = gen_array_clone(SpdmSession::new(), 4);
         context.common.session[0].setup(session_id).unwrap();
         context.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,

--- a/spdmlib/src/responder/end_session_rsp.rs
+++ b/spdmlib/src/responder/end_session_rsp.rs
@@ -46,18 +46,20 @@ impl<'a> ResponderContext<'a> {
 #[cfg(test)]
 mod tests_responder {
     use super::*;
+    use crate::common::gen_array_clone;
     use crate::common::session::SpdmSession;
     use crate::message::SpdmMessageHeader;
     use crate::testlib::*;
     use crate::{crypto, responder};
     use codec::{Codec, Writer};
+
     #[test]
     fn test_case0_handle_spdm_end_session() {
         let (config_info, provision_info) = create_info();
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         let mut context = responder::ResponderContext::new(
             &mut socket_io_transport,
             pcidoe_transport_encap,
@@ -84,7 +86,7 @@ mod tests_responder {
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         let rsp_session_id = 0xffu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
-        context.common.session = [SpdmSession::new(); 4];
+        context.common.session = gen_array_clone(SpdmSession::new(), 4);
         context.common.session[0].setup(session_id).unwrap();
         context.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,

--- a/spdmlib/src/responder/error_rsp.rs
+++ b/spdmlib/src/responder/error_rsp.rs
@@ -48,7 +48,7 @@ mod tests_responder {
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         let mut context = responder::ResponderContext::new(
             &mut socket_io_transport,
             pcidoe_transport_encap,

--- a/spdmlib/src/responder/heartbeat_rsp.rs
+++ b/spdmlib/src/responder/heartbeat_rsp.rs
@@ -42,6 +42,7 @@ impl<'a> ResponderContext<'a> {
 #[cfg(test)]
 mod tests_responder {
     use super::*;
+    use crate::common::gen_array_clone;
     use crate::common::session::SpdmSession;
     use crate::message::SpdmMessageHeader;
     use crate::testlib::*;
@@ -54,7 +55,7 @@ mod tests_responder {
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         let mut context = responder::ResponderContext::new(
             &mut socket_io_transport,
             pcidoe_transport_encap,
@@ -65,7 +66,7 @@ mod tests_responder {
         let rsp_session_id = 0xffu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
-        context.common.session = [SpdmSession::new(); 4];
+        context.common.session = gen_array_clone(SpdmSession::new(), 4);
         context.common.session[0].setup(session_id).unwrap();
         context.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,

--- a/spdmlib/src/responder/key_update_rsp.rs
+++ b/spdmlib/src/responder/key_update_rsp.rs
@@ -26,7 +26,7 @@ impl<'a> ResponderContext<'a> {
         SpdmMessageHeader::read(&mut reader);
 
         let key_update_req = SpdmKeyUpdateRequestPayload::spdm_read(&mut self.common, &mut reader);
-        if let Some(key_update_req) = key_update_req {
+        if let Some(key_update_req) = &key_update_req {
             debug!("!!! key_update req : {:02x?}\n", key_update_req);
         } else {
             error!("!!! key_update req : fail !!!\n");
@@ -74,6 +74,7 @@ impl<'a> ResponderContext<'a> {
 #[cfg(test)]
 mod tests_responder {
     use super::*;
+    use crate::common::gen_array_clone;
     use crate::common::session::SpdmSession;
     use crate::message::SpdmMessageHeader;
     use crate::testlib::*;
@@ -93,12 +94,12 @@ mod tests_responder {
             provision_info,
         );
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let rsp_session_id = 0xFFFEu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
-        context.common.session = [SpdmSession::new(); 4];
+        context.common.session = gen_array_clone(SpdmSession::new(), 4);
         context.common.session[0].setup(session_id).unwrap();
         context.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
@@ -136,7 +137,7 @@ mod tests_responder {
     fn test_case1_handle_spdm_key_update() {
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let (config_info, provision_info) = create_info();
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let mut context = responder::ResponderContext::new(
@@ -149,7 +150,7 @@ mod tests_responder {
         let rsp_session_id = 0xFFFEu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
-        context.common.session = [SpdmSession::new(); 4];
+        context.common.session = gen_array_clone(SpdmSession::new(), 4);
         context.common.session[0].setup(session_id).unwrap();
         context.common.session[0].set_crypto_param(
             SpdmBaseHashAlgo::TPM_ALG_SHA_384,

--- a/spdmlib/src/responder/measurement_rsp.rs
+++ b/spdmlib/src/responder/measurement_rsp.rs
@@ -34,7 +34,7 @@ impl<'a> ResponderContext<'a> {
 
         let get_measurements =
             SpdmGetMeasurementsRequestPayload::spdm_read(&mut self.common, &mut reader);
-        if let Some(get_measurements) = get_measurements {
+        if let Some(get_measurements) = &get_measurements {
             debug!("!!! get_measurements : {:02x?}\n", get_measurements);
         } else {
             error!("!!! get_measurements : fail !!!\n");
@@ -197,7 +197,7 @@ mod tests_responder {
             provision_info,
         );
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
@@ -330,7 +330,7 @@ mod tests_responder {
             provision_info,
         );
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;

--- a/spdmlib/src/responder/vendor_rsp.rs
+++ b/spdmlib/src/responder/vendor_rsp.rs
@@ -70,7 +70,7 @@ mod tests_requester {
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let mut responder = ResponderContext::new(
             &mut device_io_responder,

--- a/spdmlib/src/responder/version_rsp.rs
+++ b/spdmlib/src/responder/version_rsp.rs
@@ -82,7 +82,7 @@ mod tests_responder {
         let (config_info, provision_info) = create_info();
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        crypto::asym_sign::register(ASYM_SIGN_IMPL);
+        crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);

--- a/spdmlib/src/secret/mod.rs
+++ b/spdmlib/src/secret/mod.rs
@@ -88,7 +88,7 @@ pub fn spdm_measurement_collection(
     measurement_index: usize,
 ) -> Option<SpdmMeasurementRecordStructure> {
     (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED)
+        .try_get_or_init(|| UNIMPLETEMTED.clone())
         .ok()?
         .spdm_measurement_collection_cb)(
         spdm_version,
@@ -106,7 +106,7 @@ pub fn spdm_generate_measurement_summary_hash(
     measurement_summary_hash_type: SpdmMeasurementSummaryHashType,
 ) -> Option<SpdmDigestStruct> {
     (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED)
+        .try_get_or_init(|| UNIMPLETEMTED.clone())
         .ok()?
         .spdm_generate_measurement_summary_hash_cb)(
         spdm_version,
@@ -127,7 +127,7 @@ pub fn spdm_requester_data_sign(
     message_size: u8,
 ) -> Option<SpdmSignatureStruct> {
     (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED)
+        .try_get_or_init(|| UNIMPLETEMTED.clone())
         .ok()?
         .spdm_requester_data_sign_cb)(
         spdm_version,
@@ -150,7 +150,7 @@ pub fn spdm_responder_data_sign(
     message_size: u8,
 ) -> Option<SpdmSignatureStruct> {
     (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED)
+        .try_get_or_init(|| UNIMPLETEMTED.clone())
         .ok()?
         .spdm_responder_data_sign_cb)(
         spdm_version,
@@ -172,7 +172,7 @@ pub fn spdm_psk_handshake_secret_hkdf_expand(
     info_size: Option<usize>,
 ) -> Option<SpdmHKDFKeyStruct> {
     (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED)
+        .try_get_or_init(|| UNIMPLETEMTED.clone())
         .ok()?
         .spdm_psk_handshake_secret_hkdf_expand_cb)(
         spdm_version,
@@ -193,7 +193,7 @@ pub fn spdm_psk_master_secret_hkdf_expand(
     info_size: Option<usize>,
 ) -> Option<SpdmHKDFKeyStruct> {
     (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED)
+        .try_get_or_init(|| UNIMPLETEMTED.clone())
         .ok()?
         .spdm_psk_master_secret_hkdf_expand_cb)(
         spdm_version,

--- a/spdmlib/src/secret/secret_callback.rs
+++ b/spdmlib/src/secret/secret_callback.rs
@@ -59,7 +59,7 @@ type SpdmPskMasterSecretHkdfExpandCbType = fn(
     info_size: Option<usize>,
 ) -> Option<SpdmHKDFKeyStruct>;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SpdmSecret {
     pub spdm_measurement_collection_cb: SpdmMeasurementCollectionCbType,
 

--- a/spdmlib/src/testlib.rs
+++ b/spdmlib/src/testlib.rs
@@ -93,7 +93,7 @@ pub fn create_info() -> (common::SpdmConfigInfo, common::SpdmProvisionInfo) {
         .copy_from_slice(leaf_cert.as_ref());
 
     let provision_info = common::SpdmProvisionInfo {
-        my_cert_chain_data: Some(my_cert_chain_data),
+        my_cert_chain_data: Some(my_cert_chain_data.clone()),
         my_cert_chain: None,
         peer_cert_chain_data: Some(my_cert_chain_data),
         peer_cert_chain_root_hash: None,
@@ -136,7 +136,7 @@ enum_builder! {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct PciDoeMessageHeader {
     pub vendor_id: PciDoeVendorId,
     pub data_object_type: PciDoeDataObjectType,
@@ -447,7 +447,7 @@ pub static HMAC_TEST: SpdmHmac = SpdmHmac {
 fn hmac(_base_hash_algo: SpdmBaseHashAlgo, _key: &[u8], _data: &[u8]) -> Option<SpdmDigestStruct> {
     let tag = SpdmDigestStruct {
         data_size: 48,
-        data: [10u8; SPDM_MAX_HASH_SIZE],
+        data: Box::new([10u8; SPDM_MAX_HASH_SIZE]),
     };
     Some(tag)
 }

--- a/spdmlib/tests/test_client_server.rs
+++ b/spdmlib/tests/test_client_server.rs
@@ -13,7 +13,7 @@ use spdmlib::responder;
 
 #[test]
 fn intergration_client_server() {
-    spdmlib::crypto::asym_sign::register(common::crypto_callbacks::ASYM_SIGN_IMPL);
+    spdmlib::crypto::asym_sign::register(common::crypto_callbacks::ASYM_SIGN_IMPL.clone());
 
     let shared_buffer = SharedBuffer::new();
     let device_io_responder = &mut FakeSpdmDeviceIoReceve::new(&shared_buffer);

--- a/test/spdm-emu/src/secret_impl_sample.rs
+++ b/test/spdm-emu/src/secret_impl_sample.rs
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn test_case0_spdm_measurement_collection() {
-        let reg_result = register(SECRET_IMPL_INSTANCE);
+        let reg_result = register(SECRET_IMPL_INSTANCE.clone());
         assert_eq!(reg_result, true);
 
         let records = spdm_measurement_collection(

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -82,7 +82,7 @@ fn new_logger_from_env() -> SimpleLogger {
 fn main() {
     new_logger_from_env().init().unwrap();
 
-    register(SECRET_IMPL_INSTANCE);
+    register(SECRET_IMPL_INSTANCE.clone());
 
     let listener = TcpListener::bind("127.0.0.1:2323").expect("Couldn't bind to the server");
     println!("server start!");
@@ -215,15 +215,13 @@ fn handle_message(
         peer_cert_chain_root_hash: None,
     };
 
-    spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL);
-
+    spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
     let mut context = responder::ResponderContext::new(
         &mut socket_io_transport,
         transport_encap,
         config_info,
         provision_info,
     );
-
     loop {
         // if failed, receieved message can't be processed. then the message will need caller to deal.
         // now caller need to deal with message in context.


### PR DESCRIPTION
Fix: #18 

Change is listed below
1. Introduced zeroize crate, home page https://docs.rs/zeroize/latest/zeroize/ .
2. Remove all the derived Copy trait, now object gets implicit moved or explicit cloned.
3. Fixed bugs which got introduced by #2

Signed-off-by: Longlong Yang <longlong.yang@intel.com>