### PR TITLE
Timeout: need implement the timeout according to SPDM spec.

### DIFF
--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -38,7 +38,7 @@ pub const OPAQUE_DATA_VERSION_SELECTION: [u8; 16] = [
 pub trait SpdmDeviceIo {
     fn send(&mut self, buffer: &[u8]) -> SpdmResult;
 
-    fn receive(&mut self, buffer: &mut [u8]) -> Result<usize, usize>;
+    fn receive(&mut self, buffer: &mut [u8], timeout: usize) -> Result<usize, usize>;
 
     fn flush_all(&mut self) -> SpdmResult;
 }

--- a/spdmlib/src/requester/challenge_req.rs
+++ b/spdmlib/src/requester/challenge_req.rs
@@ -22,7 +22,7 @@ impl<'a> RequesterContext<'a> {
 
         // Receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, true)?;
         self.handle_spdm_challenge_response(
             0, // NULL
             measurement_summary_hash_type,

--- a/spdmlib/src/requester/end_session_req.rs
+++ b/spdmlib/src/requester/end_session_req.rs
@@ -14,7 +14,7 @@ impl<'a> RequesterContext<'a> {
         self.send_secured_message(session_id, &send_buffer[..used], false)?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
         self.handle_spdm_end_session_response(session_id, &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/finish_req.rs
+++ b/spdmlib/src/requester/finish_req.rs
@@ -19,7 +19,7 @@ impl<'a> RequesterContext<'a> {
         self.send_secured_message(session_id, &send_buffer[..send_used], false)?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
         self.handle_spdm_finish_response(
             session_id,
             base_hash_size,

--- a/spdmlib/src/requester/get_capabilities_req.rs
+++ b/spdmlib/src/requester/get_capabilities_req.rs
@@ -13,7 +13,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..send_used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_capability_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/get_certificate_req.rs
+++ b/spdmlib/src/requester/get_certificate_req.rs
@@ -21,7 +21,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..send_used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_certificate_partial_response(
             0,
             offset,

--- a/spdmlib/src/requester/get_digests_req.rs
+++ b/spdmlib/src/requester/get_digests_req.rs
@@ -14,7 +14,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..send_used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_digest_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/get_measurements_req.rs
+++ b/spdmlib/src/requester/get_measurements_req.rs
@@ -35,8 +35,10 @@ impl<'a> RequesterContext<'a> {
         // Receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
         let used = match session_id {
-            Some(session_id) => self.receive_secured_message(session_id, &mut receive_buffer)?,
-            None => self.receive_message(&mut receive_buffer)?,
+            Some(session_id) => {
+                self.receive_secured_message(session_id, &mut receive_buffer, true)?
+            }
+            None => self.receive_message(&mut receive_buffer, true)?,
         };
 
         self.handle_spdm_measurement_record_response(

--- a/spdmlib/src/requester/get_version_req.rs
+++ b/spdmlib/src/requester/get_version_req.rs
@@ -13,7 +13,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..send_used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_version_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/heartbeat_req.rs
+++ b/spdmlib/src/requester/heartbeat_req.rs
@@ -15,7 +15,7 @@ impl<'a> RequesterContext<'a> {
 
         // Receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
         self.handle_spdm_heartbeat_response(session_id, &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/key_exchange_req.rs
+++ b/spdmlib/src/requester/key_exchange_req.rs
@@ -35,7 +35,7 @@ impl<'a> RequesterContext<'a> {
 
         // Receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let receive_used = self.receive_message(&mut receive_buffer)?;
+        let receive_used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_key_exhcange_response(
             0,
             &send_buffer[..send_used],

--- a/spdmlib/src/requester/key_update_req.rs
+++ b/spdmlib/src/requester/key_update_req.rs
@@ -25,7 +25,7 @@ impl<'a> RequesterContext<'a> {
         let update_responder = key_update_operation == SpdmKeyUpdateOperation::SpdmUpdateAllKeys;
         session.create_data_secret_update(update_requester, update_responder)?;
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
 
         self.handle_spdm_key_update_op_response(
             session_id,

--- a/spdmlib/src/requester/negotiate_algorithms_req.rs
+++ b/spdmlib/src/requester/negotiate_algorithms_req.rs
@@ -13,7 +13,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..send_used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_algorithm_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/psk_exchange_req.rs
+++ b/spdmlib/src/requester/psk_exchange_req.rs
@@ -31,7 +31,7 @@ impl<'a> RequesterContext<'a> {
 
         // Receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let receive_used = self.receive_message(&mut receive_buffer)?;
+        let receive_used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_psk_exchange_response(
             0,
             measurement_summary_hash_type,

--- a/spdmlib/src/requester/psk_finish_req.rs
+++ b/spdmlib/src/requester/psk_finish_req.rs
@@ -17,7 +17,7 @@ impl<'a> RequesterContext<'a> {
         self.send_secured_message(session_id, &send_buffer[..send_used], false)?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
         self.handle_spdm_psk_finish_response(session_id, message_f, &receive_buffer[..receive_used])
     }
 

--- a/spdmlib/src/requester/respond_if_ready_req.rs
+++ b/spdmlib/src/requester/respond_if_ready_req.rs
@@ -30,7 +30,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
 
         //Have a sanity check!
         let mut reader = Reader::init(&receive_buffer);

--- a/spdmlib/src/requester/vendor_req.rs
+++ b/spdmlib/src/requester/vendor_req.rs
@@ -36,7 +36,7 @@ impl<'a> RequesterContext<'a> {
 
         //receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
-        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
 
         self.handle_spdm_vendor_defined_respond(session_id, &receive_buffer[..receive_used])
     }


### PR DESCRIPTION
fix #204 
Add timeout to receive according SPDM spec to solve issue #204.
Notably, RTT is *NOT* calculated in timeout. When provisioning,
RTT need to be taken into account.

Signed-off-by: Longlong Yang <longlong.yang@intel.com>