### PR TITLE
Timeout: need implement the timeout according to SPDM spec.

### DIFF
--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -38,7 +38,7 @@ pub const OPAQUE_DATA_VERSION_SELECTION: [u8; 16] = [
 pub trait SpdmDeviceIo {
     fn send(&mut self, buffer: &[u8]) -> SpdmResult;
 
-    fn receive(&mut self, buffer: &mut [u8]) -> Result<usize, usize>;
+    fn receive(&mut self, buffer: &mut [u8], timeout: usize) -> Result<usize, usize>;
 
     fn flush_all(&mut self) -> SpdmResult;
 }

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -35,6 +35,13 @@ pub const OPAQUE_DATA_VERSION_SELECTION: [u8; 16] = [
     0x46, 0x54, 0x4d, 0x44, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01, 0x00, 0x00, 0x11,
 ];
 
+/// The maximum amount of time the Responder has to provide a
+/// response to requests that do not require cryptographic processing, such
+/// as the GET_CAPABILITIES , GET_VERSION , or NEGOTIATE_ALGORITHMS
+/// request messages. See SPDM spec. 1.1.0  Page 29 for more information:
+/// https://www.dmtf.org/sites/default/files/standards/documents/DSP0274_1.1.0.pdf
+pub const ST1: usize = 1_000_000;
+
 pub trait SpdmDeviceIo {
     fn send(&mut self, buffer: &[u8]) -> SpdmResult;
 

--- a/spdmlib/src/requester/challenge_req.rs
+++ b/spdmlib/src/requester/challenge_req.rs
@@ -22,7 +22,7 @@ impl<'a> RequesterContext<'a> {
 
         // Receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, true)?;
         self.handle_spdm_challenge_response(
             0, // NULL
             measurement_summary_hash_type,

--- a/spdmlib/src/requester/context.rs
+++ b/spdmlib/src/requester/context.rs
@@ -4,6 +4,7 @@
 
 use crate::common::algo::SpdmMeasurementSummaryHashType;
 use crate::common::error::SpdmResult;
+use crate::common::ST1;
 use crate::common::{self, SpdmDeviceIo, SpdmTransportEncap};
 use crate::config;
 
@@ -113,7 +114,7 @@ impl<'a> RequesterContext<'a> {
         if crypto_request {
             timeout = 2 << self.common.negotiate_info.rsp_ct_exponent_sel;
         } else {
-            timeout = 100_000;
+            timeout = ST1;
         }
 
         let mut transport_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
@@ -138,7 +139,7 @@ impl<'a> RequesterContext<'a> {
         if crypto_request {
             timeout = 2 << self.common.negotiate_info.rsp_ct_exponent_sel;
         } else {
-            timeout = 100_000;
+            timeout = ST1;
         }
 
         let mut transport_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];

--- a/spdmlib/src/requester/end_session_req.rs
+++ b/spdmlib/src/requester/end_session_req.rs
@@ -14,7 +14,7 @@ impl<'a> RequesterContext<'a> {
         self.send_secured_message(session_id, &send_buffer[..used], false)?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
         self.handle_spdm_end_session_response(session_id, &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/finish_req.rs
+++ b/spdmlib/src/requester/finish_req.rs
@@ -19,7 +19,7 @@ impl<'a> RequesterContext<'a> {
         self.send_secured_message(session_id, &send_buffer[..send_used], false)?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
         self.handle_spdm_finish_response(
             session_id,
             base_hash_size,

--- a/spdmlib/src/requester/get_capabilities_req.rs
+++ b/spdmlib/src/requester/get_capabilities_req.rs
@@ -13,7 +13,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..send_used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_capability_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/get_certificate_req.rs
+++ b/spdmlib/src/requester/get_certificate_req.rs
@@ -21,7 +21,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..send_used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_certificate_partial_response(
             0,
             offset,

--- a/spdmlib/src/requester/get_digests_req.rs
+++ b/spdmlib/src/requester/get_digests_req.rs
@@ -14,7 +14,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..send_used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_digest_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/get_measurements_req.rs
+++ b/spdmlib/src/requester/get_measurements_req.rs
@@ -35,8 +35,10 @@ impl<'a> RequesterContext<'a> {
         // Receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
         let used = match session_id {
-            Some(session_id) => self.receive_secured_message(session_id, &mut receive_buffer)?,
-            None => self.receive_message(&mut receive_buffer)?,
+            Some(session_id) => {
+                self.receive_secured_message(session_id, &mut receive_buffer, true)?
+            }
+            None => self.receive_message(&mut receive_buffer, true)?,
         };
 
         self.handle_spdm_measurement_record_response(

--- a/spdmlib/src/requester/get_version_req.rs
+++ b/spdmlib/src/requester/get_version_req.rs
@@ -13,7 +13,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..send_used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_version_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/heartbeat_req.rs
+++ b/spdmlib/src/requester/heartbeat_req.rs
@@ -15,7 +15,7 @@ impl<'a> RequesterContext<'a> {
 
         // Receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
         self.handle_spdm_heartbeat_response(session_id, &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/key_exchange_req.rs
+++ b/spdmlib/src/requester/key_exchange_req.rs
@@ -35,7 +35,7 @@ impl<'a> RequesterContext<'a> {
 
         // Receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let receive_used = self.receive_message(&mut receive_buffer)?;
+        let receive_used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_key_exhcange_response(
             0,
             &send_buffer[..send_used],

--- a/spdmlib/src/requester/key_update_req.rs
+++ b/spdmlib/src/requester/key_update_req.rs
@@ -25,7 +25,7 @@ impl<'a> RequesterContext<'a> {
         let update_responder = key_update_operation == SpdmKeyUpdateOperation::SpdmUpdateAllKeys;
         session.create_data_secret_update(update_requester, update_responder)?;
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
 
         self.handle_spdm_key_update_op_response(
             session_id,

--- a/spdmlib/src/requester/negotiate_algorithms_req.rs
+++ b/spdmlib/src/requester/negotiate_algorithms_req.rs
@@ -13,7 +13,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..send_used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_algorithm_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }
 

--- a/spdmlib/src/requester/psk_exchange_req.rs
+++ b/spdmlib/src/requester/psk_exchange_req.rs
@@ -31,7 +31,7 @@ impl<'a> RequesterContext<'a> {
 
         // Receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let receive_used = self.receive_message(&mut receive_buffer)?;
+        let receive_used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_psk_exchange_response(
             0,
             measurement_summary_hash_type,

--- a/spdmlib/src/requester/psk_finish_req.rs
+++ b/spdmlib/src/requester/psk_finish_req.rs
@@ -17,7 +17,7 @@ impl<'a> RequesterContext<'a> {
         self.send_secured_message(session_id, &send_buffer[..send_used], false)?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
         self.handle_spdm_psk_finish_response(session_id, message_f, &receive_buffer[..receive_used])
     }
 

--- a/spdmlib/src/requester/respond_if_ready_req.rs
+++ b/spdmlib/src/requester/respond_if_ready_req.rs
@@ -30,7 +30,7 @@ impl<'a> RequesterContext<'a> {
         self.send_message(&send_buffer[..used])?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let used = self.receive_message(&mut receive_buffer)?;
+        let used = self.receive_message(&mut receive_buffer, false)?;
 
         //Have a sanity check!
         let mut reader = Reader::init(&receive_buffer);

--- a/spdmlib/src/requester/vendor_req.rs
+++ b/spdmlib/src/requester/vendor_req.rs
@@ -36,7 +36,7 @@ impl<'a> RequesterContext<'a> {
 
         //receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
-        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer)?;
+        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
 
         self.handle_spdm_vendor_defined_respond(session_id, &receive_buffer[..receive_used])
     }

--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -294,6 +294,7 @@ mod tests_responder {
     use super::*;
     use crate::common::gen_array_clone;
     use crate::common::session::*;
+    use crate::common::ST1;
     use crate::message::SpdmMessageHeader;
     use crate::testlib::*;
     use crate::{crypto, responder};
@@ -406,7 +407,7 @@ mod tests_responder {
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
         let status = context
-            .receive_message(&mut receive_buffer[..], 1000_000)
+            .receive_message(&mut receive_buffer[..], ST1)
             .is_ok();
         assert!(status);
     }
@@ -448,7 +449,7 @@ mod tests_responder {
         context.common.session[0]
             .set_session_state(common::session::SpdmSessionState::SpdmSessionHandshaking);
 
-        let status = context.process_message(1000_000).is_err();
+        let status = context.process_message(ST1).is_err();
         assert!(status);
     }
     #[test]

--- a/spdmlib/src/testlib.rs
+++ b/spdmlib/src/testlib.rs
@@ -109,7 +109,7 @@ impl SpdmDeviceIo for MySpdmDeviceIo {
         todo!()
     }
 
-    fn receive(&mut self, _buffer: &mut [u8]) -> Result<usize, usize> {
+    fn receive(&mut self, _buffer: &mut [u8], _timeout: usize) -> Result<usize, usize> {
         todo!()
     }
 
@@ -327,7 +327,7 @@ impl<'a> FakeSpdmDeviceIo<'a> {
 }
 
 impl SpdmDeviceIo for FakeSpdmDeviceIo<'_> {
-    fn receive(&mut self, read_buffer: &mut [u8]) -> Result<usize, usize> {
+    fn receive(&mut self, read_buffer: &mut [u8], _timeout: usize) -> Result<usize, usize> {
         let len = self.data.get_buffer(read_buffer);
         log::info!("requester receive RAW - {:02x?}\n", &read_buffer[0..len]);
         Ok(len)
@@ -337,7 +337,7 @@ impl SpdmDeviceIo for FakeSpdmDeviceIo<'_> {
         self.data.set_buffer(buffer);
         log::info!("requester send    RAW - {:02x?}\n", buffer);
 
-        if self.responder.process_message().is_err() {
+        if self.responder.process_message(ST1).is_err() {
             return spdm_result_err!(ENOMEM);
         }
         Ok(())
@@ -360,7 +360,7 @@ impl<'a> SpdmDeviceIoReceve<'a> {
 }
 
 impl SpdmDeviceIo for SpdmDeviceIoReceve<'_> {
-    fn receive(&mut self, read_buffer: &mut [u8]) -> Result<usize, usize> {
+    fn receive(&mut self, read_buffer: &mut [u8], _timeout: usize) -> Result<usize, usize> {
         let len = self.data.get_buffer(read_buffer);
         log::info!("responder receive RAW - {:02x?}\n", &read_buffer[0..len]);
         Ok(len)
@@ -388,7 +388,7 @@ impl<'a> FakeSpdmDeviceIoReceve<'a> {
 }
 
 impl SpdmDeviceIo for FakeSpdmDeviceIoReceve<'_> {
-    fn receive(&mut self, read_buffer: &mut [u8]) -> Result<usize, usize> {
+    fn receive(&mut self, read_buffer: &mut [u8], _timeout: usize) -> Result<usize, usize> {
         let len = self.data.get_buffer(read_buffer);
         log::info!("responder receive RAW - {:02x?}\n", &read_buffer[0..len]);
         Ok(len)

--- a/test/spdm-emu/src/socket_io_transport.rs
+++ b/test/spdm-emu/src/socket_io_transport.rs
@@ -27,10 +27,10 @@ impl<'a> SocketIoTransport<'a> {
 }
 
 impl SpdmDeviceIo for SocketIoTransport<'_> {
-    fn receive(&mut self, read_buffer: &mut [u8]) -> Result<usize, usize> {
+    fn receive(&mut self, read_buffer: &mut [u8], timeout: usize) -> Result<usize, usize> {
         let mut buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
 
-        if let Some((_, command, payload)) = receive_message(self.data, &mut buffer[..]) {
+        if let Some((_, command, payload)) = receive_message(self.data, &mut buffer[..], timeout) {
             // TBD: do we need this?
             // self.transport_type = transport_type;
             let used = payload.len();

--- a/test/spdm-emu/src/spdm_emu.rs
+++ b/test/spdm-emu/src/spdm_emu.rs
@@ -52,6 +52,7 @@ impl Codec for SpdmSocketHeader {
 pub fn receive_message<'a>(
     stream: &mut TcpStream,
     buffer: &'a mut [u8],
+    _timeout: usize,
 ) -> Option<(u32, u32, &'a [u8])> {
     let mut buffer_size = 0;
     let mut expected_size = 0;

--- a/test/spdm-emu/src/tcp_transport.rs
+++ b/test/spdm-emu/src/tcp_transport.rs
@@ -15,7 +15,7 @@ pub struct TcpTransport<'a> {
 }
 
 impl SpdmDeviceIo for TcpTransport<'_> {
-    fn receive(&mut self, buffer: &mut [u8]) -> Result<usize, usize> {
+    fn receive(&mut self, buffer: &mut [u8], _timeout: usize) -> Result<usize, usize> {
         let res = self.data.read(buffer).ok();
         if let Some(size) = res {
             Ok(size)

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -11,6 +11,7 @@ use log::*;
 use simple_logger::SimpleLogger;
 
 use spdmlib::common;
+use spdmlib::common::ST1;
 use spdmlib::config;
 use spdmlib::message::*;
 use spdmlib::requester;
@@ -41,7 +42,7 @@ fn send_receive_hello(
     );
     let mut buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
     let (_transport_type, _command, _payload) =
-        spdm_emu::spdm_emu::receive_message(stream, &mut buffer[..]).unwrap();
+        spdm_emu::spdm_emu::receive_message(stream, &mut buffer[..], ST1).unwrap();
 }
 
 fn send_receive_stop(
@@ -63,7 +64,7 @@ fn send_receive_stop(
     );
     let mut buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
     let (_transport_type, _command, _payload) =
-        spdm_emu::spdm_emu::receive_message(stream, &mut buffer[..]).unwrap();
+        spdm_emu::spdm_emu::receive_message(stream, &mut buffer[..], ST1).unwrap();
 }
 
 fn test_spdm(

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -12,6 +12,7 @@ use std::u32;
 
 use codec::{Codec, Reader, Writer};
 use common::SpdmTransportEncap;
+use common::ST1;
 use mctp_transport::MctpTransportEncap;
 use pcidoe_transport::{
     PciDoeDataObjectType, PciDoeMessageHeader, PciDoeTransportEncap, PciDoeVendorId,
@@ -20,9 +21,8 @@ use spdm_emu::crypto_callback::ASYM_SIGN_IMPL;
 use spdm_emu::secret_impl_sample::*;
 use spdm_emu::socket_io_transport::SocketIoTransport;
 use spdm_emu::spdm_emu::*;
-use spdmlib::message::*;
 use spdmlib::secret::*;
-use spdmlib::{common, responder};
+use spdmlib::{common, message::*, responder};
 
 fn process_socket_message(
     stream: &mut TcpStream,
@@ -225,7 +225,7 @@ fn handle_message(
     loop {
         // if failed, receieved message can't be processed. then the message will need caller to deal.
         // now caller need to deal with message in context.
-        let res = context.process_message();
+        let res = context.process_message(ST1);
         match res {
             Ok(spdm_result) => {
                 if spdm_result {


### PR DESCRIPTION
fix #204 
Add timeout to receive according SPDM spec to solve issue #204.
Notably, RTT is *NOT* calculated in timeout. When provisioning,
RTT need to be taken into account.

Signed-off-by: Longlong Yang [longlong.yang@intel.com](mailto:longlong.yang@intel.com)