### PR TITLE
Spdm1.2 transcript: Add support to Spdm1.2 key_exchange_rsp signing

### DIFF
--- a/spdmlib/src/crypto/spdm_ring/asym_verify_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/asym_verify_impl.rs
@@ -93,11 +93,6 @@ fn asym_verify(
                     //debug!("der signature len - 0x{:x?}\n", der_sign_size);
                     //debug!("der signature - {:x?}\n", der_signature);
 
-                    debug!(
-                        "longlong: data:{:02X?}, der_sign_size:{:02X?}\n",
-                        data, der_sign_size
-                    );
-
                     match cert.verify_signature(algorithm, data, &der_signature[..(der_sign_size)])
                     {
                         Ok(()) => Ok(()),

--- a/spdmlib/src/requester/get_capabilities_req.rs
+++ b/spdmlib/src/requester/get_capabilities_req.rs
@@ -72,12 +72,7 @@ impl<'a> RequesterContext<'a> {
                             .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))?;
                         message_vca
                             .append_message(&receive_buffer[..used])
-                            .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))?;
-                        debug!(
-                            "longlong:message_a:get_capabilities: {:02x?}",
-                            &receive_buffer[..used]
-                        );
-                        Ok(())
+                            .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))
                     } else {
                         error!("!!! capabilities : fail !!!\n");
                         spdm_result_err!(EFAULT)

--- a/spdmlib/src/requester/get_measurements_req.rs
+++ b/spdmlib/src/requester/get_measurements_req.rs
@@ -124,7 +124,6 @@ impl<'a> RequesterContext<'a> {
                             message_m
                                 .append_message(&receive_buffer[..temp_used])
                                 .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))?;
-                            debug!("longlong:message_m:{:02X?}\n", message_m);
                             if self
                                 .common
                                 .verify_measurement_signature(session_id, &measurements.signature)

--- a/spdmlib/src/requester/get_version_req.rs
+++ b/spdmlib/src/requester/get_version_req.rs
@@ -36,10 +36,6 @@ impl<'a> RequesterContext<'a> {
         send_buffer: &[u8],
         receive_buffer: &[u8],
     ) -> SpdmResult {
-        debug!(
-            "longlong:message_a:get_version:raw buffer: {:02x?}",
-            receive_buffer
-        );
         let mut reader = Reader::init(receive_buffer);
         match SpdmMessageHeader::read(&mut reader) {
             Some(message_header) => match message_header.request_response_code {
@@ -86,12 +82,7 @@ impl<'a> RequesterContext<'a> {
                             .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))?;
                         message_vca
                             .append_message(&receive_buffer[..used])
-                            .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))?;
-                        debug!(
-                            "longlong:message_a:get_version: {:02x?}",
-                            &receive_buffer[..used]
-                        );
-                        Ok(())
+                            .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))
                     } else {
                         error!("!!! version : fail !!!\n");
                         spdm_result_err!(EFAULT)

--- a/spdmlib/src/requester/key_exchange_req.rs
+++ b/spdmlib/src/requester/key_exchange_req.rs
@@ -63,12 +63,24 @@ impl<'a> RequesterContext<'a> {
                 .ok_or(spdm_err!(EFAULT))?;
 
         debug!("!!! exchange data : {:02x?}\n", exchange);
-        let mut opaque = SpdmOpaqueStruct {
-            data_size: crate::common::OPAQUE_DATA_SUPPORT_VERSION.len() as u16,
-            ..Default::default()
-        };
-        opaque.data[..(opaque.data_size as usize)]
-            .copy_from_slice(crate::common::OPAQUE_DATA_SUPPORT_VERSION.as_ref());
+
+        let mut opaque;
+        if self.common.negotiate_info.spdm_version_sel == SpdmVersion::SpdmVersion12 {
+            opaque = SpdmOpaqueStruct {
+                data_size: crate::common::OPAQUE_DATA_SUPPORT_VERSION_SPDM12.len() as u16,
+                ..Default::default()
+            };
+            opaque.data[..(opaque.data_size as usize)]
+                .copy_from_slice(crate::common::OPAQUE_DATA_SUPPORT_VERSION_SPDM12.as_ref());
+        } else {
+            opaque = SpdmOpaqueStruct {
+                data_size: crate::common::OPAQUE_DATA_SUPPORT_VERSION.len() as u16,
+                ..Default::default()
+            };
+            opaque.data[..(opaque.data_size as usize)]
+                .copy_from_slice(crate::common::OPAQUE_DATA_SUPPORT_VERSION.as_ref());
+        }
+
         let request = SpdmMessage {
             header: SpdmMessageHeader {
                 version: self.common.negotiate_info.spdm_version_sel,

--- a/spdmlib/src/requester/negotiate_algorithms_req.rs
+++ b/spdmlib/src/requester/negotiate_algorithms_req.rs
@@ -135,10 +135,6 @@ impl<'a> RequesterContext<'a> {
                         message_vca
                             .append_message(&receive_buffer[..used])
                             .map_or_else(|| spdm_result_err!(ENOMEM), |_| Ok(()))?;
-                        debug!(
-                            "longlong:message_a:negotiate_algorithms: {:02x?}",
-                            &receive_buffer[..used]
-                        );
                         return Ok(());
                     }
                     error!("!!! algorithms : fail !!!\n");

--- a/spdmlib/src/requester/psk_exchange_req.rs
+++ b/spdmlib/src/requester/psk_exchange_req.rs
@@ -52,12 +52,22 @@ impl<'a> RequesterContext<'a> {
         let mut psk_context = [0u8; MAX_SPDM_PSK_CONTEXT_SIZE];
         crypto::rand::get_random(&mut psk_context)?;
 
-        let mut opaque = SpdmOpaqueStruct {
-            data_size: crate::common::OPAQUE_DATA_SUPPORT_VERSION.len() as u16,
-            ..Default::default()
-        };
-        opaque.data[..(opaque.data_size as usize)]
-            .copy_from_slice(crate::common::OPAQUE_DATA_SUPPORT_VERSION.as_ref());
+        let mut opaque;
+        if self.common.negotiate_info.spdm_version_sel == SpdmVersion::SpdmVersion12 {
+            opaque = SpdmOpaqueStruct {
+                data_size: crate::common::OPAQUE_DATA_SUPPORT_VERSION_SPDM12.len() as u16,
+                ..Default::default()
+            };
+            opaque.data[..(opaque.data_size as usize)]
+                .copy_from_slice(crate::common::OPAQUE_DATA_SUPPORT_VERSION_SPDM12.as_ref());
+        } else {
+            opaque = SpdmOpaqueStruct {
+                data_size: crate::common::OPAQUE_DATA_SUPPORT_VERSION.len() as u16,
+                ..Default::default()
+            };
+            opaque.data[..(opaque.data_size as usize)]
+                .copy_from_slice(crate::common::OPAQUE_DATA_SUPPORT_VERSION.as_ref());
+        }
         let request = SpdmMessage {
             header: SpdmMessageHeader {
                 version: self.common.negotiate_info.spdm_version_sel,


### PR DESCRIPTION
fix #199 

As per specification of SPDM1.2, change transcript calculation to support
1. SPDMsign(PrivKey, transcript, "key_exchange_rsp signing");
2. SPDMsignatureVerify(PubKey,signature, transcript, "key_exchange_rsp signing");

Signed-off-by: Longlong Yang <longlong.yang@intel.com>