### PR TITLE
Spdm1.2: Add support to SessionPolicy and ContentChange

### DIFF
--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -681,6 +681,8 @@ pub struct SpdmConfigInfo {
     pub req_asym_algo: SpdmReqAsymAlgo,
     pub key_schedule_algo: SpdmKeyScheduleAlgo,
     pub opaque_support: SpdmOpaqueSupport,
+    pub session_policy: u8,
+    pub runtime_content_change_support: bool,
 }
 
 #[derive(Debug, Default)]
@@ -699,6 +701,7 @@ pub struct SpdmNegotiateInfo {
     pub req_asym_sel: SpdmReqAsymAlgo,
     pub key_schedule_sel: SpdmKeyScheduleAlgo,
     pub opaque_data_support: SpdmOpaqueSupport,
+    pub termination_policy_set: bool, // used by responder to take action when code or configuration changed.
 }
 
 // TBD ManagedSmallBuffer
@@ -739,6 +742,7 @@ pub struct SpdmRuntimeInfo {
     pub message_c: ManagedBuffer,
     pub message_m: ManagedBuffer,
     pub message_vca: ManagedBuffer,
+    pub content_changed: bool, // used by responder, when content changed and spdm version is 1.2, set to true.
 }
 
 #[derive(Default, Clone)]

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -1010,7 +1010,9 @@ mod tests {
             payload: SpdmMessagePayload::SpdmMeasurementsResponse(
                 SpdmMeasurementsResponsePayload {
                     number_of_measurement: 100u8,
-                    slot_id: 100u8,
+                    slot_id: 7u8,
+                    content_changed:
+                        MEASUREMENT_RESPONDER_PARAM2_CONTENT_CHANGED_NOT_SUPPORTED_VALUE,
                     measurement_record: SpdmMeasurementRecordStructure {
                         number_of_blocks: 5,
                         record: gen_array_clone(
@@ -1054,7 +1056,11 @@ mod tests {
         );
         if let SpdmMessagePayload::SpdmMeasurementsResponse(payload) = &spdm_message.payload {
             assert_eq!(payload.number_of_measurement, 100);
-            assert_eq!(payload.slot_id, 100);
+            assert_eq!(payload.slot_id, 7);
+            assert_eq!(
+                payload.content_changed,
+                MEASUREMENT_RESPONDER_PARAM2_CONTENT_CHANGED_NOT_SUPPORTED_VALUE
+            );
             assert_eq!(payload.measurement_record.number_of_blocks, 5);
             for i in 0..5 {
                 assert_eq!(payload.measurement_record.record[i].index, 100);
@@ -1112,6 +1118,7 @@ mod tests {
                     SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeNone,
                 slot_id: 100u8,
                 req_session_id: 100u16,
+                session_policy: 1,
                 random: SpdmRandomStruct {
                     data: [100u8; SPDM_RANDOM_SIZE],
                 },

--- a/spdmlib/src/requester/key_exchange_req.rs
+++ b/spdmlib/src/requester/key_exchange_req.rs
@@ -90,6 +90,7 @@ impl<'a> RequesterContext<'a> {
                 slot_id,
                 measurement_summary_hash_type,
                 req_session_id,
+                session_policy: self.common.config_info.session_policy,
                 random: SpdmRandomStruct { data: random },
                 exchange,
                 opaque,

--- a/spdmlib/src/responder/key_exchange_rsp.rs
+++ b/spdmlib/src/responder/key_exchange_rsp.rs
@@ -38,6 +38,15 @@ impl<'a> ResponderContext<'a> {
             } else {
                 self.common.runtime_info.need_measurement_summary_hash = false;
             }
+
+            if key_exchange_req.session_policy
+                & KEY_EXCHANGE_REQUESTER_SESSION_POLICY_TERMINATION_POLICY_MASK
+                == KEY_EXCHANGE_REQUESTER_SESSION_POLICY_TERMINATION_POLICY_VALUE
+            {
+                self.common.negotiate_info.termination_policy_set = true;
+            } else {
+                self.common.negotiate_info.termination_policy_set = false;
+            }
         } else {
             error!("!!! key_exchange req : fail !!!\n");
             self.write_spdm_error(SpdmErrorCode::SpdmErrorInvalidRequest, 0, writer);
@@ -261,6 +270,7 @@ mod tests_responder {
                 SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeTcb,
             slot_id: 100u8,
             req_session_id: 0xffu16,
+            session_policy: 1,
             random: SpdmRandomStruct {
                 data: [100u8; SPDM_RANDOM_SIZE],
             },

--- a/spdmlib/src/responder/measurement_rsp.rs
+++ b/spdmlib/src/responder/measurement_rsp.rs
@@ -112,6 +112,18 @@ impl<'a> ResponderContext<'a> {
             SpdmMeasurementRecordStructure::default()
         };
 
+        let content_changed = if self.common.config_info.runtime_content_change_support
+            && self.common.negotiate_info.spdm_version_sel == SpdmVersion::SpdmVersion12
+        {
+            if self.common.runtime_info.content_changed {
+                MEASUREMENT_RESPONDER_PARAM2_CONTENT_CHANGED_DETECTED_CHANGE_VALUE
+            } else {
+                MEASUREMENT_RESPONDER_PARAM2_CONTENT_CHANGED_NO_CHANGE_VALUE
+            }
+        } else {
+            MEASUREMENT_RESPONDER_PARAM2_CONTENT_CHANGED_NOT_SUPPORTED_VALUE
+        };
+
         let response = SpdmMessage {
             header: SpdmMessageHeader {
                 version: self.common.negotiate_info.spdm_version_sel,
@@ -121,6 +133,7 @@ impl<'a> ResponderContext<'a> {
                 SpdmMeasurementsResponsePayload {
                     number_of_measurement,
                     slot_id: get_measurements.slot_id,
+                    content_changed,
                     measurement_record,
                     nonce: SpdmNonceStruct { data: nonce },
                     opaque: SpdmOpaqueStruct {


### PR DESCRIPTION
fix #231 and #232

Add the missing parts of Spdm1.2 new features MEASUREMENTS response param2
ContentChange and KEY_EXCHANGE request SessionPolicy.

Signed-off-by: Longlong Yang <longlong.yang@intel.com>