### PR TITLE
measurement: add RawBitStreamRequested support to SpdmMeasurementeAttributes

### DIFF
--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -743,6 +743,7 @@ pub struct SpdmRuntimeInfo {
     pub message_m: ManagedBuffer,
     pub message_vca: ManagedBuffer,
     pub content_changed: bool, // used by responder, when content changed and spdm version is 1.2, set to true.
+                               // used by requester, when measurement response report content changed, set to false after consumed.
 }
 
 #[derive(Default, Clone)]

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -966,7 +966,7 @@ mod tests {
             },
             payload: SpdmMessagePayload::SpdmGetMeasurementsRequest(
                 SpdmGetMeasurementsRequestPayload {
-                    measurement_attributes: SpdmMeasurementeAttributes::INCLUDE_SIGNATURE,
+                    measurement_attributes: SpdmMeasurementeAttributes::SIGNATURE_REQUESTED,
                     measurement_operation:
                         SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber,
                     nonce: SpdmNonceStruct {
@@ -985,7 +985,7 @@ mod tests {
         if let SpdmMessagePayload::SpdmGetMeasurementsRequest(payload) = &spdm_message.payload {
             assert_eq!(
                 payload.measurement_attributes,
-                SpdmMeasurementeAttributes::INCLUDE_SIGNATURE
+                SpdmMeasurementeAttributes::SIGNATURE_REQUESTED
             );
             assert_eq!(
                 payload.measurement_operation,

--- a/spdmlib/src/responder/measurement_rsp.rs
+++ b/spdmlib/src/responder/measurement_rsp.rs
@@ -47,7 +47,7 @@ impl<'a> ResponderContext<'a> {
 
         if get_measurements
             .measurement_attributes
-            .contains(SpdmMeasurementeAttributes::INCLUDE_SIGNATURE)
+            .contains(SpdmMeasurementeAttributes::SIGNATURE_REQUESTED)
         {
             self.common.runtime_info.need_measurement_signature = true;
         } else {
@@ -153,7 +153,7 @@ impl<'a> ResponderContext<'a> {
         // generat signature
         if get_measurements
             .measurement_attributes
-            .contains(SpdmMeasurementeAttributes::INCLUDE_SIGNATURE)
+            .contains(SpdmMeasurementeAttributes::SIGNATURE_REQUESTED)
         {
             let base_asym_size = self.common.negotiate_info.base_asym_sel.get_size() as usize;
             let temp_used = used - base_asym_size;

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -185,10 +185,14 @@ fn test_spdm(
         return;
     }
 
+    let mut total_number: u8 = 0;
+
     if context
         .send_receive_spdm_measurement(
             None,
+            SpdmMeasurementeAttributes::SIGNATURE_REQUESTED,
             SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber,
+            &mut total_number,
             0,
         )
         .is_err()
@@ -238,7 +242,9 @@ fn test_spdm(
         if context
             .send_receive_spdm_measurement(
                 Some(session_id),
+                SpdmMeasurementeAttributes::SIGNATURE_REQUESTED,
                 SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber,
+                &mut total_number,
                 0,
             )
             .is_err()


### PR DESCRIPTION
1. add RAW_BIT_STREAM_REQUESTED to SpdmMeasurementeAttributes
2. as per SPDM spec., change INCLUDE_SIGNATURE in SpdmMeasurementeAttributes
to SIGNATURE_REQUESTED
3. send_receive_spdm_measurement api signature is changed to be able to pass
spdm_measuremente_attributes and get total_number as output
4. get_measurements request to set content changed in runtime info.

Signed-off-by: Longlong Yang <longlong.yang@intel.com>