### PR TITLE
Common: add data_transfer_size and max_spdm_msg_size to SpdmConfigInfo

### DIFF
--- a/mctp_transport/src/header.rs
+++ b/mctp_transport/src/header.rs
@@ -184,7 +184,7 @@ mod tests {
     #[test]
     fn test_case0_encap() {
         let mut mctp_transport_encap = MctpTransportEncap {};
-        let mut transport_buffer = [100u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut transport_buffer = [100u8; config::DATA_TRANSFER_SIZE];
         let spdm_buffer = [100u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
 
         let status = mctp_transport_encap
@@ -197,8 +197,8 @@ mod tests {
             .is_ok();
         assert!(status);
 
-        let mut transport_buffer = [100u8; config::MAX_SPDM_TRANSPORT_SIZE];
-        let spdm_buffer = [100u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut transport_buffer = [100u8; config::DATA_TRANSFER_SIZE];
+        let spdm_buffer = [100u8; config::DATA_TRANSFER_SIZE];
         let status = mctp_transport_encap
             .encap(&spdm_buffer, &mut transport_buffer, true)
             .is_err();
@@ -208,7 +208,7 @@ mod tests {
     fn test_case0_decap() {
         let mut mctp_transport_encap = MctpTransportEncap {};
 
-        let mut spdm_buffer = [100u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut spdm_buffer = [100u8; config::DATA_TRANSFER_SIZE];
 
         let transport_buffer = &mut [0u8; 10];
 
@@ -262,7 +262,7 @@ mod tests {
     fn test_case0_decap_app() {
         let mut mctp_transport_encap = MctpTransportEncap {};
 
-        let mut spdm_buffer = [100u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut spdm_buffer = [100u8; config::DATA_TRANSFER_SIZE];
 
         let transport_buffer = &mut [0u8; 10];
 

--- a/spdmlib/build.rs
+++ b/spdmlib/build.rs
@@ -20,7 +20,8 @@ struct SpdmConfig {
     vendor_defined_config: SpdmVendorDefinedConfig,
     max_session_count: usize,
     max_msg_buffer_size: usize,
-    max_transport_size: usize,
+    data_transfer_size: usize,
+    max_spdm_msg_size: usize,
 }
 
 impl SpdmConfig {
@@ -29,7 +30,7 @@ impl SpdmConfig {
         // This will be checked by the compiler thus no need to check again here.
 
         // Check if meet SPDM requirements.
-        assert!(self.cert_config.max_cert_portion_len < self.max_transport_size);
+        assert!(self.cert_config.max_cert_portion_len < self.data_transfer_size);
         assert!(self.max_opaque_size < 1024);
 
         // TODO: add more sanity checks if needed.
@@ -120,8 +121,11 @@ pub const MAX_SPDM_SESSION_COUNT: usize = {session_cnt};
 /// This is used in SpdmRuntimeInfo. max cached size
 pub const MAX_SPDM_MESSAGE_BUFFER_SIZE: usize = {msg_buf_sz}; // 0x1200
 
-/// This is used in Transport
-pub const MAX_SPDM_TRANSPORT_SIZE: usize = {trans_sz}; // MAX_SPDM_MESSAGE_BUFFER_SIZE + 0x100(For upper layer headers)
+/// This is used in Transport, SPDM 1.2
+pub const DATA_TRANSFER_SIZE: usize = {trans_sz}; // MAX_SPDM_MESSAGE_BUFFER_SIZE + 0x100(For upper layer headers)
+
+/// SPDM 1.2
+pub const MAX_SPDM_MSG_SIZE: usize = {max_spdm_mgs_sz}; // set to equal to DATA_TRANSFER_SIZE @todo
 
 /// This is used in vendor defined message transport
 pub const MAX_SPDM_VENDOR_DEFINED_VENDOR_ID_LEN: usize = {vendor_id_len};
@@ -166,7 +170,8 @@ fn main() {
         psk_hint_sz = spdm_config.psk_config.max_psk_hint_size,
         session_cnt = spdm_config.max_session_count,
         msg_buf_sz = spdm_config.max_msg_buffer_size,
-        trans_sz = spdm_config.max_transport_size,
+        trans_sz = spdm_config.data_transfer_size,
+        max_spdm_mgs_sz = spdm_config.max_spdm_msg_size,
         vendor_id_len = spdm_config
             .vendor_defined_config
             .max_vendor_defined_vendor_id_len,

--- a/spdmlib/etc/config.json
+++ b/spdmlib/etc/config.json
@@ -26,5 +26,6 @@
     },
     "max_session_count": 4,
     "max_msg_buffer_size": 4608,
-    "max_transport_size": 4864
+    "data_transfer_size": 4864,
+    "max_spdm_msg_size": 4864
 }

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -637,7 +637,7 @@ impl<'a> SpdmContext<'a> {
         transport_buffer: &[u8],
         receive_buffer: &mut [u8],
     ) -> SpdmResult<usize> {
-        let mut encoded_receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut encoded_receive_buffer = [0u8; config::DATA_TRANSFER_SIZE];
         let (used, secured_message) = self
             .transport_encap
             .decap(transport_buffer, &mut encoded_receive_buffer)?;
@@ -683,6 +683,8 @@ pub struct SpdmConfigInfo {
     pub opaque_support: SpdmOpaqueSupport,
     pub session_policy: u8,
     pub runtime_content_change_support: bool,
+    pub data_transfer_size: u32,
+    pub max_spdm_msg_size: u32,
 }
 
 #[derive(Debug, Default)]
@@ -702,6 +704,10 @@ pub struct SpdmNegotiateInfo {
     pub key_schedule_sel: SpdmKeyScheduleAlgo,
     pub opaque_data_support: SpdmOpaqueSupport,
     pub termination_policy_set: bool, // used by responder to take action when code or configuration changed.
+    pub req_data_transfer_size_sel: u32, // spdm 1.2
+    pub req_max_spdm_msg_size_sel: u32, // spdm 1.2
+    pub rsp_data_transfer_size_sel: u32, // spdm 1.2
+    pub rsp_max_spdm_msg_size_sel: u32, // spdm 1.2
 }
 
 // TBD ManagedSmallBuffer

--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -814,7 +814,7 @@ impl SpdmSession {
 
         let cipher_text_size = length as usize - tag_size;
 
-        let mut plain_text_buf = [0; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut plain_text_buf = [0; config::DATA_TRANSFER_SIZE];
 
         let mut salt = secret_param.salt.data.clone();
         let sequence_number = secret_param.sequence_number;

--- a/spdmlib/src/requester/context.rs
+++ b/spdmlib/src/requester/context.rs
@@ -81,7 +81,7 @@ impl<'a> RequesterContext<'a> {
     }
 
     pub fn send_message(&mut self, send_buffer: &[u8]) -> SpdmResult {
-        let mut transport_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
         let used = self.common.encap(send_buffer, &mut transport_buffer)?;
         self.common.device_io.send(&transport_buffer[..used])
     }
@@ -92,7 +92,7 @@ impl<'a> RequesterContext<'a> {
         send_buffer: &[u8],
         is_app_message: bool,
     ) -> SpdmResult {
-        let mut transport_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
         let used = self.common.encode_secured_message(
             session_id,
             send_buffer,
@@ -117,7 +117,7 @@ impl<'a> RequesterContext<'a> {
             timeout = ST1;
         }
 
-        let mut transport_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
         let used = self
             .common
             .device_io
@@ -142,7 +142,7 @@ impl<'a> RequesterContext<'a> {
             timeout = ST1;
         }
 
-        let mut transport_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
 
         let used = self
             .common

--- a/spdmlib/src/requester/get_capabilities_req.rs
+++ b/spdmlib/src/requester/get_capabilities_req.rs
@@ -28,8 +28,8 @@ impl<'a> RequesterContext<'a> {
                 SpdmGetCapabilitiesRequestPayload {
                     ct_exponent: self.common.config_info.req_ct_exponent,
                     flags: self.common.config_info.req_capabilities,
-                    data_transfer_size: config::MAX_SPDM_MESSAGE_BUFFER_SIZE as u32,
-                    max_spdm_msg_size: config::MAX_SPDM_MESSAGE_BUFFER_SIZE as u32,
+                    data_transfer_size: self.common.config_info.data_transfer_size,
+                    max_spdm_msg_size: self.common.config_info.max_spdm_msg_size,
                 },
             ),
         };
@@ -58,6 +58,18 @@ impl<'a> RequesterContext<'a> {
                             self.common.config_info.req_capabilities;
                         self.common.negotiate_info.rsp_ct_exponent_sel = capabilities.ct_exponent;
                         self.common.negotiate_info.rsp_capabilities_sel = capabilities.flags;
+
+                        if self.common.negotiate_info.spdm_version_sel == SpdmVersion::SpdmVersion12
+                        {
+                            self.common.negotiate_info.req_data_transfer_size_sel =
+                                self.common.config_info.data_transfer_size;
+                            self.common.negotiate_info.req_max_spdm_msg_size_sel =
+                                self.common.config_info.max_spdm_msg_size;
+                            self.common.negotiate_info.rsp_data_transfer_size_sel =
+                                capabilities.data_transfer_size;
+                            self.common.negotiate_info.rsp_max_spdm_msg_size_sel =
+                                capabilities.max_spdm_msg_size;
+                        }
 
                         let message_a = &mut self.common.runtime_info.message_a;
                         message_a

--- a/spdmlib/src/responder/capability_rsp.rs
+++ b/spdmlib/src/responder/capability_rsp.rs
@@ -38,6 +38,17 @@ impl<'a> ResponderContext<'a> {
                 self.common.config_info.rsp_ct_exponent;
             self.common.negotiate_info.rsp_capabilities_sel =
                 self.common.config_info.rsp_capabilities;
+
+            if self.common.negotiate_info.spdm_version_sel == SpdmVersion::SpdmVersion12 {
+                self.common.negotiate_info.req_data_transfer_size_sel =
+                    get_capabilities.data_transfer_size;
+                self.common.negotiate_info.req_max_spdm_msg_size_sel =
+                    get_capabilities.max_spdm_msg_size;
+                self.common.negotiate_info.rsp_data_transfer_size_sel =
+                    self.common.config_info.data_transfer_size;
+                self.common.negotiate_info.rsp_max_spdm_msg_size_sel =
+                    self.common.config_info.max_spdm_msg_size;
+            }
         } else {
             error!("!!! get_capabilities : fail !!!\n");
             self.write_spdm_error(SpdmErrorCode::SpdmErrorInvalidRequest, 0, writer);
@@ -75,8 +86,8 @@ impl<'a> ResponderContext<'a> {
                 SpdmCapabilitiesResponsePayload {
                     ct_exponent: self.common.config_info.rsp_ct_exponent,
                     flags: self.common.config_info.rsp_capabilities,
-                    data_transfer_size: config::MAX_SPDM_MESSAGE_BUFFER_SIZE as u32,
-                    max_spdm_msg_size: config::MAX_SPDM_MESSAGE_BUFFER_SIZE as u32,
+                    data_transfer_size: self.common.config_info.data_transfer_size,
+                    max_spdm_msg_size: self.common.config_info.max_spdm_msg_size,
                 },
             ),
         };

--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -37,7 +37,7 @@ impl<'a> ResponderContext<'a> {
     }
 
     pub fn send_message(&mut self, send_buffer: &[u8]) -> SpdmResult {
-        let mut transport_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
         let used = self.common.encap(send_buffer, &mut transport_buffer)?;
         self.common.device_io.send(&transport_buffer[..used])
     }
@@ -48,7 +48,7 @@ impl<'a> ResponderContext<'a> {
         send_buffer: &[u8],
         is_app_message: bool,
     ) -> SpdmResult {
-        let mut transport_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
         let used = self.common.encode_secured_message(
             session_id,
             send_buffer,
@@ -62,8 +62,8 @@ impl<'a> ResponderContext<'a> {
     pub fn process_message(
         &mut self,
         timeout: usize,
-    ) -> Result<bool, (usize, [u8; config::MAX_SPDM_TRANSPORT_SIZE])> {
-        let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+    ) -> Result<bool, (usize, [u8; config::DATA_TRANSFER_SIZE])> {
+        let mut receive_buffer = [0u8; config::DATA_TRANSFER_SIZE];
         match self.receive_message(&mut receive_buffer[..], timeout) {
             Ok((used, secured_message)) => {
                 if secured_message {
@@ -124,7 +124,7 @@ impl<'a> ResponderContext<'a> {
     ) -> Result<(usize, bool), usize> {
         info!("receive_message!\n");
 
-        let mut transport_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
 
         let used = self.common.device_io.receive(receive_buffer, timeout)?;
 
@@ -389,7 +389,7 @@ mod tests_responder {
     }
     #[test]
     fn test_case0_receive_message() {
-        let receive_buffer = &mut [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let receive_buffer = &mut [0u8; config::DATA_TRANSFER_SIZE];
         let mut writer = Writer::init(receive_buffer);
         let value = PciDoeMessageHeader {
             vendor_id: PciDoeVendorId::PciDoeVendorIdPciSig,
@@ -412,7 +412,7 @@ mod tests_responder {
             provision_info,
         );
 
-        let mut receive_buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut receive_buffer = [0u8; config::DATA_TRANSFER_SIZE];
         let status = context
             .receive_message(&mut receive_buffer[..], ST1)
             .is_ok();

--- a/spdmlib/tests/common/utils.rs
+++ b/spdmlib/tests/common/utils.rs
@@ -5,6 +5,7 @@
 use super::{USE_ECDH, USE_ECDSA};
 use spdmlib::common;
 use spdmlib::common::SpdmOpaqueSupport;
+use spdmlib::config;
 use spdmlib::message::*;
 use std::path::PathBuf;
 
@@ -51,6 +52,8 @@ pub fn req_create_info() -> (common::SpdmConfigInfo, common::SpdmProvisionInfo) 
         req_asym_algo: SpdmReqAsymAlgo::TPM_ALG_RSAPSS_2048,
         key_schedule_algo: SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         opaque_support: SpdmOpaqueSupport::OPAQUE_DATA_FMT1,
+        data_transfer_size: config::DATA_TRANSFER_SIZE as u32,
+        max_spdm_msg_size: config::MAX_SPDM_MSG_SIZE as u32,
         ..Default::default()
     };
 
@@ -143,6 +146,8 @@ pub fn rsp_create_info() -> (common::SpdmConfigInfo, common::SpdmProvisionInfo) 
         req_asym_algo: SpdmReqAsymAlgo::TPM_ALG_RSAPSS_2048,
         key_schedule_algo: SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         opaque_support: SpdmOpaqueSupport::OPAQUE_DATA_FMT1,
+        data_transfer_size: config::DATA_TRANSFER_SIZE as u32,
+        max_spdm_msg_size: config::MAX_SPDM_MSG_SIZE as u32,
         ..Default::default()
     };
 

--- a/test/spdm-emu/src/socket_io_transport.rs
+++ b/test/spdm-emu/src/socket_io_transport.rs
@@ -28,7 +28,7 @@ impl<'a> SocketIoTransport<'a> {
 
 impl SpdmDeviceIo for SocketIoTransport<'_> {
     fn receive(&mut self, read_buffer: &mut [u8], timeout: usize) -> Result<usize, usize> {
-        let mut buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+        let mut buffer = [0u8; config::DATA_TRANSFER_SIZE];
 
         if let Some((_, command, payload)) = receive_message(self.data, &mut buffer[..], timeout) {
             // TBD: do we need this?

--- a/test/spdm-emu/src/spdm_emu.rs
+++ b/test/spdm-emu/src/spdm_emu.rs
@@ -99,7 +99,7 @@ pub fn send_message(
     command: u32,
     payload: &[u8],
 ) -> usize {
-    let mut buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+    let mut buffer = [0u8; config::DATA_TRANSFER_SIZE];
 
     let mut writer = Writer::init(&mut buffer);
     let payload_size = payload.len();

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -41,7 +41,7 @@ fn send_receive_hello(
         SOCKET_SPDM_COMMAND_TEST,
         &payload[0..used],
     );
-    let mut buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+    let mut buffer = [0u8; config::DATA_TRANSFER_SIZE];
     let (_transport_type, _command, _payload) =
         spdm_emu::spdm_emu::receive_message(stream, &mut buffer[..], ST1).unwrap();
 }
@@ -63,7 +63,7 @@ fn send_receive_stop(
         SOCKET_SPDM_COMMAND_STOP,
         &payload[0..used],
     );
-    let mut buffer = [0u8; config::MAX_SPDM_TRANSPORT_SIZE];
+    let mut buffer = [0u8; config::DATA_TRANSFER_SIZE];
     let (_transport_type, _command, _payload) =
         spdm_emu::spdm_emu::receive_message(stream, &mut buffer[..], ST1).unwrap();
 }
@@ -106,6 +106,8 @@ fn test_spdm(
         req_asym_algo: SpdmReqAsymAlgo::TPM_ALG_RSAPSS_2048,
         key_schedule_algo: SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         opaque_support: SpdmOpaqueSupport::OPAQUE_DATA_FMT1,
+        data_transfer_size: config::DATA_TRANSFER_SIZE as u32,
+        max_spdm_msg_size: config::MAX_SPDM_MSG_SIZE as u32,
         ..Default::default()
     };
 

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -132,7 +132,7 @@ fn main() {
 fn handle_message(
     stream: &mut TcpStream,
     transport_encap: &mut dyn SpdmTransportEncap,
-) -> Result<bool, (usize, [u8; config::MAX_SPDM_TRANSPORT_SIZE])> {
+) -> Result<bool, (usize, [u8; config::DATA_TRANSFER_SIZE])> {
     println!("handle_message!");
     let mut socket_io_transport = SocketIoTransport::new(stream);
 
@@ -173,6 +173,8 @@ fn handle_message(
         req_asym_algo: SpdmReqAsymAlgo::TPM_ALG_RSAPSS_2048,
         key_schedule_algo: SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         opaque_support: SpdmOpaqueSupport::OPAQUE_DATA_FMT1,
+        data_transfer_size: config::DATA_TRANSFER_SIZE as u32,
+        max_spdm_msg_size: config::MAX_SPDM_MSG_SIZE as u32,
         ..Default::default()
     };
 


### PR DESCRIPTION
1. add data_transfer_size and max_spdm_msg_size to SpdmConfigInfo
2. add req_data_transfer_size_sel req_max_spdm_msg_size_sel: u32
   and rsp_data_transfer_size_sel rsp_max_spdm_msg_size_sel: u32
   to SpdmNegotiateInfo

Signed-off-by: Longlong Yang <longlong.yang@intel.com>