### PR TITLE
key_exchange: add heartbeat_period to SpdmSession

### DIFF
--- a/spdmlib/build.rs
+++ b/spdmlib/build.rs
@@ -22,6 +22,7 @@ struct SpdmConfig {
     max_msg_buffer_size: usize,
     data_transfer_size: usize,
     max_spdm_msg_size: usize,
+    heartbeat_period_value: u8,
 }
 
 impl SpdmConfig {
@@ -130,6 +131,11 @@ pub const MAX_SPDM_MSG_SIZE: usize = {max_spdm_mgs_sz}; // set to equal to DATA_
 /// This is used in vendor defined message transport
 pub const MAX_SPDM_VENDOR_DEFINED_VENDOR_ID_LEN: usize = {vendor_id_len};
 pub const MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE: usize = {vendor_payload_sz};
+
+/// This is used by responder to specify the heartbeat period
+/// 0 represents either Heartbeat is not supported or
+/// heartbeat is not desired on a session
+pub const HEARTBEAT_PERIOD: u8 = {heartbeat_period};
 "
 };
 }
@@ -177,7 +183,8 @@ fn main() {
             .max_vendor_defined_vendor_id_len,
         vendor_payload_sz = spdm_config
             .vendor_defined_config
-            .max_vendor_defined_payload_size
+            .max_vendor_defined_payload_size,
+        heartbeat_period = spdm_config.heartbeat_period_value,
     )
     .expect("Failed to generate configuration code from the template and JSON config");
 

--- a/spdmlib/etc/config.json
+++ b/spdmlib/etc/config.json
@@ -27,5 +27,6 @@
     "max_session_count": 4,
     "max_msg_buffer_size": 4608,
     "data_transfer_size": 4864,
-    "max_spdm_msg_size": 4864
+    "max_spdm_msg_size": 4864,
+    "heartbeat_period_value": 0
 }

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -685,6 +685,7 @@ pub struct SpdmConfigInfo {
     pub runtime_content_change_support: bool,
     pub data_transfer_size: u32,
     pub max_spdm_msg_size: u32,
+    pub heartbeat_period: u8, // used by responder only
 }
 
 #[derive(Debug, Default)]

--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -95,6 +95,7 @@ pub struct SpdmSession {
     transport_param: SpdmSessionTransportParam,
     pub runtime_info: SpdmSessionRuntimeInfo,
     key_schedule: SpdmKeySchedule,
+    pub heartbeat_period: u8, // valid only when HEARTBEAT cap set
 }
 
 impl Default for SpdmSession {
@@ -117,6 +118,7 @@ impl SpdmSession {
             transport_param: SpdmSessionTransportParam::default(),
             runtime_info: SpdmSessionRuntimeInfo::default(),
             key_schedule: SpdmKeySchedule::new(),
+            heartbeat_period: 0,
         }
     }
 

--- a/spdmlib/src/requester/key_exchange_req.rs
+++ b/spdmlib/src/requester/key_exchange_req.rs
@@ -233,6 +233,8 @@ impl<'a> RequesterContext<'a> {
                             crate::common::session::SpdmSessionState::SpdmSessionHandshaking,
                         );
 
+                        session.heartbeat_period = key_exchange_rsp.heartbeat_period;
+
                         Ok(session_id)
                     } else {
                         error!("!!! key_exchange : fail !!!\n");

--- a/spdmlib/src/responder/key_exchange_rsp.rs
+++ b/spdmlib/src/responder/key_exchange_rsp.rs
@@ -91,7 +91,7 @@ impl<'a> ResponderContext<'a> {
                 request_response_code: SpdmRequestResponseCode::SpdmResponseKeyExchangeRsp,
             },
             payload: SpdmMessagePayload::SpdmKeyExchangeResponse(SpdmKeyExchangeResponsePayload {
-                heartbeat_period: 0x0,
+                heartbeat_period: self.common.config_info.heartbeat_period,
                 rsp_session_id,
                 mut_auth_req: SpdmKeyExchangeMutAuthAttributes::empty(),
                 req_slot_id: 0x0,


### PR DESCRIPTION
1. add heartbeat_period to SpdmSession to let requester to record
the heartbeat_period chose by responder.

Signed-off-by: Longlong Yang <longlong.yang@intel.com>