### PR TITLE
secure_spdm_version: add secure_spdm_version support.

### DIFF
--- a/spdmlib/build.rs
+++ b/spdmlib/build.rs
@@ -23,6 +23,7 @@ struct SpdmConfig {
     data_transfer_size: usize,
     max_spdm_msg_size: usize,
     heartbeat_period_value: u8,
+    secure_spdm_version: u8,
 }
 
 impl SpdmConfig {
@@ -136,6 +137,9 @@ pub const MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE: usize = {vendor_payload_sz};
 /// 0 represents either Heartbeat is not supported or
 /// heartbeat is not desired on a session
 pub const HEARTBEAT_PERIOD: u8 = {heartbeat_period};
+
+/// This is used by responder
+pub const SECURE_SPDM_VERSION: u8 = {secure_spdm_version};
 "
 };
 }
@@ -185,6 +189,7 @@ fn main() {
             .vendor_defined_config
             .max_vendor_defined_payload_size,
         heartbeat_period = spdm_config.heartbeat_period_value,
+        secure_spdm_version = spdm_config.secure_spdm_version,
     )
     .expect("Failed to generate configuration code from the template and JSON config");
 

--- a/spdmlib/etc/config.json
+++ b/spdmlib/etc/config.json
@@ -28,5 +28,6 @@
     "max_msg_buffer_size": 4608,
     "data_transfer_size": 4864,
     "max_spdm_msg_size": 4864,
-    "heartbeat_period_value": 0
+    "heartbeat_period_value": 0,
+    "secure_spdm_version": 17
 }

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -27,21 +27,6 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::convert::TryInto;
 
-pub const OPAQUE_DATA_SUPPORT_VERSION: [u8; 20] = [
-    0x46, 0x54, 0x4d, 0x44, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x01, 0x01, 0x01, 0x00,
-    0x11, 0x00, 0x00, 0x00,
-];
-
-// uint8_t total_elements; uint8_t reserved[3]; uint8_t id; uint8_t vendor_len; uint16_t opaque_element_data_len; uint8_t sm_data_version; uint8_t sm_data_id; uint8_t version_count; uint16_t versions_list[version_count]
-
-pub const OPAQUE_DATA_SUPPORT_VERSION_SPDM12: [u8; 16] = [
-    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x01, 0x01, 0x01, 0x00, 0x10, 0x00, 0x00, 0x00,
-];
-
-pub const OPAQUE_DATA_VERSION_SELECTION: [u8; 16] = [
-    0x46, 0x54, 0x4d, 0x44, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01, 0x00, 0x00, 0x11,
-];
-
 /// The maximum amount of time the Responder has to provide a
 /// response to requests that do not require cryptographic processing, such
 /// as the GET_CAPABILITIES , GET_VERSION , or NEGOTIATE_ALGORITHMS
@@ -685,7 +670,8 @@ pub struct SpdmConfigInfo {
     pub runtime_content_change_support: bool,
     pub data_transfer_size: u32,
     pub max_spdm_msg_size: u32,
-    pub heartbeat_period: u8, // used by responder only
+    pub heartbeat_period: u8,    // used by responder only
+    pub secure_spdm_version: u8, // used by responder only
 }
 
 #[derive(Debug, Default)]

--- a/spdmlib/src/common/opaque.rs
+++ b/spdmlib/src/common/opaque.rs
@@ -7,7 +7,436 @@ use super::*;
 use crate::config;
 use codec::{Codec, Reader, Writer};
 
-//pub const SPDM_MAX_OPAQUE_SIZE : usize = 1024;
+pub const MAX_SECURE_SPDM_VERSION_COUNT: usize = 0x02;
+pub const MAX_VENDOR_ID_LENGTH: usize = 0xFF;
+pub const MAX_OPAQUE_LIST_ELEMENTS_COUNT: usize = 3;
+
+pub const DMTF_SPEC_ID: u32 = 0x444D546;
+pub const DMTF_OPAQUE_VERSION: u8 = 0x01;
+pub const SM_DATA_VERSION: u8 = 0x01;
+pub const PADDING: u8 = 0x00;
+pub const RESERVED: u8 = 0x00;
+pub const DMTF_ID: u8 = 0x00;
+pub const DMTF_VENDOR_LEN: u8 = 0x00;
+pub const OPAQUE_LIST_TOTAL_ELEMENTS: u8 = 0x01;
+pub const VERSION_SELECTION_SM_DATA_ID: u8 = 0x00;
+pub const SUPPORTED_VERSION_LIST_SM_DATA_ID: u8 = 0x01;
+
+pub const DMTF_SECURE_SPDM_VERSION_10: u8 = 0x10;
+pub const DMTF_SECURE_SPDM_VERSION_11: u8 = 0x11;
+
+pub const DMTF_SUPPORTED_SECURE_SPDM_VERSION_LIST: [SecuredMessageVersion;
+    MAX_SECURE_SPDM_VERSION_COUNT] = [
+    SecuredMessageVersion::from_secure_spdm_version(DMTF_SECURE_SPDM_VERSION_10),
+    SecuredMessageVersion::from_secure_spdm_version(DMTF_SECURE_SPDM_VERSION_11),
+];
+pub const DMTF_SECURE_SPDM_VERSION_SELECTION: SecuredMessageVersion =
+    SecuredMessageVersion::from_secure_spdm_version(DMTF_SECURE_SPDM_VERSION_10);
+
+pub const REQ_DMTF_OPAQUE_DATA_SUPPORT_VERSION_LIST_FMT0: [u8; 20] = [
+    0x46,
+    0x54,
+    0x4d,
+    0x44,
+    DMTF_OPAQUE_VERSION,
+    OPAQUE_LIST_TOTAL_ELEMENTS,
+    RESERVED,
+    RESERVED,
+    DMTF_ID,
+    DMTF_VENDOR_LEN,
+    0x07,
+    0x00,
+    SM_DATA_VERSION,
+    SUPPORTED_VERSION_LIST_SM_DATA_ID,
+    0x02,
+    0x00,
+    0x10,
+    0x00,
+    0x11,
+    PADDING,
+];
+
+pub const RSP_DMTF_OPAQUE_DATA_VERSION_SELECTION_FMT0: [u8; 16] = [
+    0x46,
+    0x54,
+    0x4d,
+    0x44,
+    DMTF_OPAQUE_VERSION,
+    OPAQUE_LIST_TOTAL_ELEMENTS,
+    RESERVED,
+    RESERVED,
+    DMTF_ID,
+    DMTF_VENDOR_LEN,
+    0x04,
+    0x00,
+    SM_DATA_VERSION,
+    VERSION_SELECTION_SM_DATA_ID,
+    0x00,
+    0x11,
+];
+
+pub const REQ_DMTF_OPAQUE_DATA_SUPPORT_VERSION_LIST_FMT1: [u8; 16] = [
+    OPAQUE_LIST_TOTAL_ELEMENTS,
+    RESERVED,
+    RESERVED,
+    RESERVED,
+    DMTF_ID,
+    DMTF_VENDOR_LEN,
+    0x07,
+    0x00,
+    SM_DATA_VERSION,
+    SUPPORTED_VERSION_LIST_SM_DATA_ID,
+    0x02,
+    0x00,
+    0x10,
+    0x00,
+    0x11,
+    PADDING,
+];
+
+pub const RSP_DMTF_OPAQUE_DATA_VERSION_SELECTION_FMT1: [u8; 12] = [
+    OPAQUE_LIST_TOTAL_ELEMENTS,
+    RESERVED,
+    RESERVED,
+    RESERVED,
+    DMTF_ID,
+    DMTF_VENDOR_LEN,
+    0x04,
+    0x00,
+    SM_DATA_VERSION,
+    VERSION_SELECTION_SM_DATA_ID,
+    0x00,
+    0x11,
+];
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SecuredMessageVersion {
+    pub major_version: u8,
+    pub minor_version: u8,
+    pub update_version_number: u8,
+    pub alpha: u8,
+}
+
+impl SpdmCodec for SecuredMessageVersion {
+    fn spdm_encode(&self, _context: &mut SpdmContext, bytes: &mut Writer) {
+        ((self.update_version_number << 4) + self.alpha).encode(bytes);
+        ((self.major_version << 4) + self.minor_version).encode(bytes);
+    }
+    fn spdm_read(_context: &mut SpdmContext, r: &mut Reader) -> Option<SecuredMessageVersion> {
+        let update_version_number_alpha = u8::read(r)?;
+        let major_version_minor_version = u8::read(r)?;
+        let update_version_number = update_version_number_alpha >> 4;
+        let alpha = update_version_number_alpha & 0x0F;
+        let major_version = major_version_minor_version >> 4;
+        let minor_version = major_version_minor_version & 0x0F;
+
+        Some(SecuredMessageVersion {
+            major_version,
+            minor_version,
+            update_version_number,
+            alpha,
+        })
+    }
+}
+
+impl SecuredMessageVersion {
+    pub fn get_secure_spdm_version(self) -> u8 {
+        (self.major_version << 4) + self.minor_version
+    }
+
+    pub const fn from_secure_spdm_version(secure_spdm_version: u8) -> Self {
+        let major_version = secure_spdm_version >> 4;
+        let minor_version = secure_spdm_version & 0x0F;
+        Self {
+            major_version,
+            minor_version,
+            update_version_number: 0,
+            alpha: 0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SecuredMessageVersionList {
+    pub version_count: u8,
+    pub versions_list: [SecuredMessageVersion; MAX_SECURE_SPDM_VERSION_COUNT],
+}
+
+impl SpdmCodec for SecuredMessageVersionList {
+    fn spdm_encode(&self, context: &mut SpdmContext, bytes: &mut Writer) {
+        self.version_count.encode(bytes);
+        for index in 0..self.version_count as usize {
+            self.versions_list[index].spdm_encode(context, bytes);
+        }
+    }
+    fn spdm_read(context: &mut SpdmContext, r: &mut Reader) -> Option<SecuredMessageVersionList> {
+        let version_count = u8::read(r)?;
+        let mut versions_list = [SecuredMessageVersion::default(); MAX_SECURE_SPDM_VERSION_COUNT];
+        for d in versions_list.iter_mut().take(version_count as usize) {
+            *d = SecuredMessageVersion::spdm_read(context, r)?;
+        }
+
+        Some(SecuredMessageVersionList {
+            version_count,
+            versions_list,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct OpaqueElementHeader {
+    pub id: u8,
+    pub vendor_len: u8,
+    pub vendor_id: [u8; MAX_VENDOR_ID_LENGTH],
+}
+
+impl Default for OpaqueElementHeader {
+    fn default() -> Self {
+        Self {
+            id: Default::default(),
+            vendor_len: Default::default(),
+            vendor_id: [0u8; MAX_VENDOR_ID_LENGTH],
+        }
+    }
+}
+
+impl SpdmCodec for OpaqueElementHeader {
+    fn spdm_encode(&self, _context: &mut SpdmContext, bytes: &mut Writer) {
+        self.id.encode(bytes);
+        self.vendor_len.encode(bytes);
+        for index in 0..self.vendor_len as usize {
+            self.vendor_id[index].encode(bytes);
+        }
+    }
+    fn spdm_read(_context: &mut SpdmContext, r: &mut Reader) -> Option<OpaqueElementHeader> {
+        let id = u8::read(r)?;
+        let vendor_len = u8::read(r)?;
+        let mut vendor_id = [0u8; MAX_VENDOR_ID_LENGTH];
+        for d in vendor_id.iter_mut().take(vendor_len as usize) {
+            *d = u8::read(r)?;
+        }
+
+        Some(OpaqueElementHeader {
+            id,
+            vendor_len,
+            vendor_id,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SecuredMessageGeneralOpaqueDataHeader {
+    pub spec_id: u32,
+    pub opaque_version: u8,
+    pub total_elements: u8,
+}
+
+impl SpdmCodec for SecuredMessageGeneralOpaqueDataHeader {
+    fn spdm_encode(&self, context: &mut SpdmContext, bytes: &mut Writer) {
+        if context
+            .negotiate_info
+            .opaque_data_support
+            .contains(SpdmOpaqueSupport::OPAQUE_DATA_FMT1)
+        {
+            self.total_elements.encode(bytes);
+            0u8.encode(bytes); // reserved 3 bytes, 1 byte here required by cargo clippy
+        } else {
+            self.spec_id.encode(bytes);
+            self.opaque_version.encode(bytes);
+            self.total_elements.encode(bytes);
+        }
+        0u16.encode(bytes); // reserved 2 bytes
+    }
+    fn spdm_read(
+        context: &mut SpdmContext,
+        r: &mut Reader,
+    ) -> Option<SecuredMessageGeneralOpaqueDataHeader> {
+        let mut spec_id: u32 = 0;
+        let mut opaque_version: u8 = 0;
+        let total_elements: u8;
+
+        if context
+            .negotiate_info
+            .opaque_data_support
+            .contains(SpdmOpaqueSupport::OPAQUE_DATA_FMT1)
+        {
+            total_elements = u8::read(r)?;
+            u8::read(r)?; // reserved 3 bytes
+            u8::read(r)?;
+            u8::read(r)?;
+        } else {
+            spec_id = u32::read(r)?;
+            opaque_version = u8::read(r)?;
+            total_elements = u8::read(r)?;
+            u16::read(r)?; // reserved 2 bytes
+        }
+
+        Some(SecuredMessageGeneralOpaqueDataHeader {
+            spec_id,
+            opaque_version,
+            total_elements,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OpaqueElementDMTFVersionSelection {
+    pub selected_version: SecuredMessageVersion,
+}
+
+impl SpdmCodec for OpaqueElementDMTFVersionSelection {
+    fn spdm_encode(&self, context: &mut SpdmContext, bytes: &mut Writer) {
+        0u8.encode(bytes); // ID: Shall be zero to indicate DMTF.
+        0u8.encode(bytes); // VendorLen: Shall be zero. Note: DMTF does not have a vendor registry.
+        4u16.encode(bytes); // OpaqueElementDataLen: Shall be the length of the remaining bytes excluding the AlignPadding.
+        1u8.encode(bytes); // SMDataVersion: Shall identify the format of the remaining bytes. The value shall be one.
+        0u8.encode(bytes); // SMDataID: Shall be a value of zero to indicate Secured Message version selection.
+        self.selected_version.spdm_encode(context, bytes);
+    }
+    fn spdm_read(
+        context: &mut SpdmContext,
+        r: &mut Reader,
+    ) -> Option<OpaqueElementDMTFVersionSelection> {
+        u8::read(r)?; // ID
+        u8::read(r)?; // VendorLen
+        u16::read(r)?; // OpaqueElementDataLen
+        u8::read(r)?; // SMDataVersion
+        u8::read(r)?; // SMDataID
+        let selected_version = SecuredMessageVersion::spdm_read(context, r)?;
+
+        Some(OpaqueElementDMTFVersionSelection { selected_version })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OpaqueElementDMTFSupportedVersion {
+    pub secured_msg_vers: SecuredMessageVersionList,
+}
+
+impl SpdmCodec for OpaqueElementDMTFSupportedVersion {
+    fn spdm_encode(&self, context: &mut SpdmContext, bytes: &mut Writer) {
+        0u8.encode(bytes); // ID: Shall be zero to indicate DMTF.
+        0u8.encode(bytes); // VendorLen: Shall be zero. Note: DMTF does not have a vendor registry.
+        let opaque_element_data_len: u16 = 3 + 2 * self.secured_msg_vers.version_count as u16; // SMDataVersion + SMDataID + self.secured_msg_vers.version_count + 2 * count
+        opaque_element_data_len.encode(bytes); // OpaqueElementDataLen: Shall be the length of the remaining bytes excluding the AlignPadding.
+        1u8.encode(bytes); // SMDataVersion: Shall identify the format of the remaining bytes. The value shall be one.
+        1u8.encode(bytes); // SMDataID: Shall be a value of one to indicate Supported version list.
+        self.secured_msg_vers.spdm_encode(context, bytes);
+
+        // padding
+        let filled = bytes.used();
+        let aligned_len = (filled + 3) & (!3);
+        let align_padding = aligned_len - filled;
+        for _i in 0..align_padding {
+            0u8.encode(bytes);
+        }
+    }
+    fn spdm_read(
+        context: &mut SpdmContext,
+        r: &mut Reader,
+    ) -> Option<OpaqueElementDMTFSupportedVersion> {
+        u8::read(r)?; // ID
+        u8::read(r)?; // VendorLen
+        u16::read(r)?; // OpaqueElementDataLen
+        u8::read(r)?; // SMDataVersion
+        u8::read(r)?; // SMDataID
+        let secured_msg_vers = SecuredMessageVersionList::spdm_read(context, r)?;
+
+        // padding
+        let read = r.used();
+        let aligned_len = (read + 3) & (!3);
+        let align_padding = aligned_len - read;
+        for _i in 0..align_padding {
+            u8::read(r)?;
+        }
+
+        Some(OpaqueElementDMTFSupportedVersion { secured_msg_vers })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SecuredMessageDMTFVersionSelection {
+    pub secured_message_general_opaque_data_header: SecuredMessageGeneralOpaqueDataHeader,
+    pub opaque_element_dmtf_version_selection_list:
+        [OpaqueElementDMTFVersionSelection; MAX_OPAQUE_LIST_ELEMENTS_COUNT],
+}
+
+impl SpdmCodec for SecuredMessageDMTFVersionSelection {
+    fn spdm_encode(&self, context: &mut SpdmContext, bytes: &mut Writer) {
+        self.secured_message_general_opaque_data_header
+            .spdm_encode(context, bytes);
+        for index in 0..self
+            .secured_message_general_opaque_data_header
+            .total_elements as usize
+        {
+            self.opaque_element_dmtf_version_selection_list[index].spdm_encode(context, bytes);
+        }
+    }
+    fn spdm_read(
+        context: &mut SpdmContext,
+        r: &mut Reader,
+    ) -> Option<SecuredMessageDMTFVersionSelection> {
+        let secured_message_general_opaque_data_header =
+            SecuredMessageGeneralOpaqueDataHeader::spdm_read(context, r)?;
+        let mut opaque_element_dmtf_version_selection_list =
+            [OpaqueElementDMTFVersionSelection::default(); MAX_OPAQUE_LIST_ELEMENTS_COUNT];
+        for d in opaque_element_dmtf_version_selection_list
+            .iter_mut()
+            .take(secured_message_general_opaque_data_header.total_elements as usize)
+        {
+            *d = OpaqueElementDMTFVersionSelection {
+                ..OpaqueElementDMTFVersionSelection::spdm_read(context, r)?
+            };
+        }
+
+        Some(SecuredMessageDMTFVersionSelection {
+            secured_message_general_opaque_data_header,
+            opaque_element_dmtf_version_selection_list,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SecuredMessageDMTFSupportedVersion {
+    pub secured_message_general_opaque_data_header: SecuredMessageGeneralOpaqueDataHeader,
+    pub opaque_element_dmtf_supported_version_list:
+        [OpaqueElementDMTFSupportedVersion; MAX_OPAQUE_LIST_ELEMENTS_COUNT],
+}
+
+impl SpdmCodec for SecuredMessageDMTFSupportedVersion {
+    fn spdm_encode(&self, context: &mut SpdmContext, bytes: &mut Writer) {
+        self.secured_message_general_opaque_data_header
+            .spdm_encode(context, bytes);
+        for index in 0..self
+            .secured_message_general_opaque_data_header
+            .total_elements as usize
+        {
+            self.opaque_element_dmtf_supported_version_list[index].spdm_encode(context, bytes);
+        }
+    }
+    fn spdm_read(
+        context: &mut SpdmContext,
+        r: &mut Reader,
+    ) -> Option<SecuredMessageDMTFSupportedVersion> {
+        let secured_message_general_opaque_data_header =
+            SecuredMessageGeneralOpaqueDataHeader::spdm_read(context, r)?;
+        let mut opaque_element_dmtf_supported_version_list =
+            [OpaqueElementDMTFSupportedVersion::default(); MAX_OPAQUE_LIST_ELEMENTS_COUNT];
+        for d in opaque_element_dmtf_supported_version_list
+            .iter_mut()
+            .take(secured_message_general_opaque_data_header.total_elements as usize)
+        {
+            *d = OpaqueElementDMTFSupportedVersion {
+                ..OpaqueElementDMTFSupportedVersion::spdm_read(context, r)?
+            };
+        }
+
+        Some(SecuredMessageDMTFSupportedVersion {
+            secured_message_general_opaque_data_header,
+            opaque_element_dmtf_supported_version_list,
+        })
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct SpdmOpaqueStruct {
@@ -24,26 +453,50 @@ impl Default for SpdmOpaqueStruct {
 }
 
 impl SpdmCodec for SpdmOpaqueStruct {
-    fn spdm_encode(&self, context: &mut SpdmContext, bytes: &mut Writer) {
-        if context.negotiate_info.opaque_data_support == SpdmOpaqueSupport::default() {
-            0u16.encode(bytes);
-        } else {
-            self.data_size.encode(bytes);
-            for d in self.data.iter().take(self.data_size as usize) {
-                d.encode(bytes);
-            }
+    fn spdm_encode(&self, _context: &mut SpdmContext, bytes: &mut Writer) {
+        self.data_size.encode(bytes);
+        for d in self.data.iter().take(self.data_size as usize) {
+            d.encode(bytes);
         }
     }
-    fn spdm_read(context: &mut SpdmContext, r: &mut Reader) -> Option<SpdmOpaqueStruct> {
+    fn spdm_read(_context: &mut SpdmContext, r: &mut Reader) -> Option<SpdmOpaqueStruct> {
         let data_size = u16::read(r)?;
         let mut data = [0u8; config::MAX_SPDM_OPAQUE_SIZE];
-        if context.negotiate_info.opaque_data_support != SpdmOpaqueSupport::default() {
-            for d in data.iter_mut().take(data_size as usize) {
-                *d = u8::read(r)?;
-            }
+        for d in data.iter_mut().take(data_size as usize) {
+            *d = u8::read(r)?;
         }
 
         Some(SpdmOpaqueStruct { data_size, data })
+    }
+}
+
+impl SpdmOpaqueStruct {
+    pub fn rsp_get_dmtf_supported_secure_spdm_version_list(
+        &self,
+        context: &mut SpdmContext,
+    ) -> Option<SecuredMessageVersionList> {
+        let mut r = Reader::init(&self.data[0..self.data_size as usize]);
+        let secured_message_dmtf_supported_version =
+            SecuredMessageDMTFSupportedVersion::spdm_read(context, &mut r)?;
+
+        Some(SecuredMessageVersionList {
+            ..secured_message_dmtf_supported_version.opaque_element_dmtf_supported_version_list[0]
+                .secured_msg_vers
+        })
+    }
+
+    pub fn req_get_dmtf_secure_spdm_version_selection(
+        &self,
+        context: &mut SpdmContext,
+    ) -> Option<SecuredMessageVersion> {
+        let mut r = Reader::init(&self.data[0..self.data_size as usize]);
+        let secured_message_dmtf_version_selection =
+            SecuredMessageDMTFVersionSelection::spdm_read(context, &mut r)?;
+
+        Some(SecuredMessageVersion {
+            ..secured_message_dmtf_version_selection.opaque_element_dmtf_version_selection_list[0]
+                .selected_version
+        })
     }
 }
 

--- a/spdmlib/src/requester/finish_req.rs
+++ b/spdmlib/src/requester/finish_req.rs
@@ -167,8 +167,11 @@ impl<'a> RequesterContext<'a> {
                             Some(&message_f),
                         )?;
                         debug!("!!! th2 : {:02x?}\n", th2.as_ref());
+                        let spdm_version_sel = self.common.negotiate_info.spdm_version_sel;
                         let session = self.common.get_session_via_id(session_id).unwrap();
-                        session.generate_data_secret(&th2).unwrap();
+                        session
+                            .generate_data_secret(spdm_version_sel, &th2)
+                            .unwrap();
                         session.set_session_state(
                             crate::common::session::SpdmSessionState::SpdmSessionEstablished,
                         );

--- a/spdmlib/src/requester/negotiate_algorithms_req.rs
+++ b/spdmlib/src/requester/negotiate_algorithms_req.rs
@@ -89,11 +89,6 @@ impl<'a> RequesterContext<'a> {
                         self.common.negotiate_info.measurement_specification_sel =
                             algorithms.measurement_specification_sel;
 
-                        assert_ne!(
-                            self.common.config_info.opaque_support
-                                & algorithms.other_params_selection,
-                            SpdmOpaqueSupport::default()
-                        );
                         self.common.negotiate_info.opaque_data_support =
                             algorithms.other_params_selection;
 

--- a/spdmlib/src/requester/psk_exchange_req.rs
+++ b/spdmlib/src/requester/psk_exchange_req.rs
@@ -53,21 +53,31 @@ impl<'a> RequesterContext<'a> {
         crypto::rand::get_random(&mut psk_context)?;
 
         let mut opaque;
-        if self.common.negotiate_info.spdm_version_sel == SpdmVersion::SpdmVersion12 {
+        if self
+            .common
+            .negotiate_info
+            .opaque_data_support
+            .contains(SpdmOpaqueSupport::OPAQUE_DATA_FMT1)
+        {
             opaque = SpdmOpaqueStruct {
-                data_size: crate::common::OPAQUE_DATA_SUPPORT_VERSION_SPDM12.len() as u16,
+                data_size: crate::common::opaque::REQ_DMTF_OPAQUE_DATA_SUPPORT_VERSION_LIST_FMT1
+                    .len() as u16,
                 ..Default::default()
             };
-            opaque.data[..(opaque.data_size as usize)]
-                .copy_from_slice(crate::common::OPAQUE_DATA_SUPPORT_VERSION_SPDM12.as_ref());
+            opaque.data[..(opaque.data_size as usize)].copy_from_slice(
+                crate::common::opaque::REQ_DMTF_OPAQUE_DATA_SUPPORT_VERSION_LIST_FMT1.as_ref(),
+            );
         } else {
             opaque = SpdmOpaqueStruct {
-                data_size: crate::common::OPAQUE_DATA_SUPPORT_VERSION.len() as u16,
+                data_size: crate::common::opaque::REQ_DMTF_OPAQUE_DATA_SUPPORT_VERSION_LIST_FMT0
+                    .len() as u16,
                 ..Default::default()
             };
-            opaque.data[..(opaque.data_size as usize)]
-                .copy_from_slice(crate::common::OPAQUE_DATA_SUPPORT_VERSION.as_ref());
+            opaque.data[..(opaque.data_size as usize)].copy_from_slice(
+                crate::common::opaque::REQ_DMTF_OPAQUE_DATA_SUPPORT_VERSION_LIST_FMT0.as_ref(),
+            );
         }
+
         let request = SpdmMessage {
             header: SpdmMessageHeader {
                 version: self.common.negotiate_info.spdm_version_sel,
@@ -140,8 +150,20 @@ impl<'a> RequesterContext<'a> {
                             self.common.transport_encap.get_sequence_number_count();
                         let max_random_count = self.common.transport_encap.get_max_random_count();
 
+                        let secure_spdm_version_sel;
+                        if let Some(secured_message_version) = psk_exchange_rsp
+                            .opaque
+                            .req_get_dmtf_secure_spdm_version_selection(&mut self.common)
+                        {
+                            secure_spdm_version_sel =
+                                secured_message_version.get_secure_spdm_version();
+                        } else {
+                            secure_spdm_version_sel = 0;
+                        }
+
                         let session_id = ((INITIAL_SESSION_ID as u32) << 16)
                             + psk_exchange_rsp.rsp_session_id as u32;
+                        let spdm_version_sel = self.common.negotiate_info.spdm_version_sel;
                         let session = self
                             .common
                             .get_next_avaiable_session()
@@ -162,8 +184,10 @@ impl<'a> RequesterContext<'a> {
                             key_schedule_algo,
                         );
                         session.set_transport_param(sequence_number_count, max_random_count);
-                        session.set_dhe_secret(psk_key); // transfer the ownership out
-                        session.generate_handshake_secret(&th1).unwrap();
+                        session.set_dhe_secret(spdm_version_sel, psk_key); // transfer the ownership out
+                        session
+                            .generate_handshake_secret(spdm_version_sel, &th1)
+                            .unwrap();
 
                         // verify HMAC with finished_key
                         let transcript_data = self
@@ -194,6 +218,9 @@ impl<'a> RequesterContext<'a> {
                         session.set_session_state(
                             crate::common::session::SpdmSessionState::SpdmSessionHandshaking,
                         );
+
+                        session.secure_spdm_version_sel = secure_spdm_version_sel;
+                        session.heartbeat_period = psk_exchange_rsp.heartbeat_period;
 
                         Ok(session_id)
                     } else {

--- a/spdmlib/src/requester/psk_finish_req.rs
+++ b/spdmlib/src/requester/psk_finish_req.rs
@@ -88,6 +88,7 @@ impl<'a> RequesterContext<'a> {
                     let receive_used = reader.used();
                     if let Some(psk_finish_rsp) = psk_finish_rsp {
                         debug!("!!! psk_finish rsp : {:02x?}\n", psk_finish_rsp);
+                        let spdm_version_sel = self.common.negotiate_info.spdm_version_sel;
                         let session = self.common.get_session_via_id(session_id).unwrap();
                         message_f
                             .append_message(&receive_buffer[..receive_used])
@@ -106,7 +107,9 @@ impl<'a> RequesterContext<'a> {
                         )?;
                         debug!("!!! th2 : {:02x?}\n", th2.as_ref());
                         let session = self.common.get_session_via_id(session_id).unwrap();
-                        session.generate_data_secret(&th2).unwrap();
+                        session
+                            .generate_data_secret(spdm_version_sel, &th2)
+                            .unwrap();
                         session.set_session_state(
                             crate::common::session::SpdmSessionState::SpdmSessionEstablished,
                         );

--- a/spdmlib/src/responder/finish_rsp.rs
+++ b/spdmlib/src/responder/finish_rsp.rs
@@ -185,8 +185,11 @@ impl<'a> ResponderContext<'a> {
         }
         let th2 = th2.unwrap();
         debug!("!!! th2 : {:02x?}\n", th2.as_ref());
+        let spdm_version_sel = self.common.negotiate_info.spdm_version_sel;
         let session = self.common.get_session_via_id(session_id).unwrap();
-        session.generate_data_secret(&th2).unwrap();
+        session
+            .generate_data_secret(spdm_version_sel, &th2)
+            .unwrap();
 
         true
     }

--- a/spdmlib/src/responder/key_update_rsp.rs
+++ b/spdmlib/src/responder/key_update_rsp.rs
@@ -35,17 +35,18 @@ impl<'a> ResponderContext<'a> {
         }
         let key_update_req = key_update_req.unwrap();
 
+        let spdm_version_sel = self.common.negotiate_info.spdm_version_sel;
         let session = self.common.get_session_via_id(session_id).unwrap();
         match key_update_req.key_update_operation {
             SpdmKeyUpdateOperation::SpdmUpdateSingleKey => {
-                let _ = session.create_data_secret_update(true, false);
+                let _ = session.create_data_secret_update(spdm_version_sel, true, false);
             }
             SpdmKeyUpdateOperation::SpdmUpdateAllKeys => {
-                let _ = session.create_data_secret_update(true, true);
-                let _ = session.activate_data_secret_update(true, true, true);
+                let _ = session.create_data_secret_update(spdm_version_sel, true, true);
+                let _ = session.activate_data_secret_update(spdm_version_sel, true, true, true);
             }
             SpdmKeyUpdateOperation::SpdmVerifyNewKey => {
-                let _ = session.activate_data_secret_update(true, false, true);
+                let _ = session.activate_data_secret_update(spdm_version_sel, true, false, true);
             }
             _ => {
                 error!("!!! key_update req : fail !!!\n");

--- a/spdmlib/src/responder/psk_finish_rsp.rs
+++ b/spdmlib/src/responder/psk_finish_rsp.rs
@@ -120,8 +120,11 @@ impl<'a> ResponderContext<'a> {
         }
         let th2 = th2.unwrap();
         debug!("!!! th2 : {:02x?}\n", th2.as_ref());
+        let spdm_version_sel = self.common.negotiate_info.spdm_version_sel;
         let session = self.common.get_session_via_id(session_id).unwrap();
-        session.generate_data_secret(&th2).unwrap();
+        session
+            .generate_data_secret(spdm_version_sel, &th2)
+            .unwrap();
 
         true
     }

--- a/spdmlib/tests/common/utils.rs
+++ b/spdmlib/tests/common/utils.rs
@@ -148,6 +148,8 @@ pub fn rsp_create_info() -> (common::SpdmConfigInfo, common::SpdmProvisionInfo) 
         opaque_support: SpdmOpaqueSupport::OPAQUE_DATA_FMT1,
         data_transfer_size: config::DATA_TRANSFER_SIZE as u32,
         max_spdm_msg_size: config::MAX_SPDM_MSG_SIZE as u32,
+        heartbeat_period: config::HEARTBEAT_PERIOD,
+        secure_spdm_version: config::SECURE_SPDM_VERSION,
         ..Default::default()
     };
 

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -175,6 +175,8 @@ fn handle_message(
         opaque_support: SpdmOpaqueSupport::OPAQUE_DATA_FMT1,
         data_transfer_size: config::DATA_TRANSFER_SIZE as u32,
         max_spdm_msg_size: config::MAX_SPDM_MSG_SIZE as u32,
+        heartbeat_period: config::HEARTBEAT_PERIOD,
+        secure_spdm_version: config::SECURE_SPDM_VERSION,
         ..Default::default()
     };
 


### PR DESCRIPTION
1. added secure_spdm_version to SpdmSession.
2. implemented Secured Messages using SPDM Specification in Opaque.rs

Signed-off-by: Longlong Yang <longlong.yang@intel.com>