### PR TITLE
peer_info: support multiple peer certificate chains

### DIFF
--- a/spdmlib/src/requester/context.rs
+++ b/spdmlib/src/requester/context.rs
@@ -51,7 +51,7 @@ impl<'a> RequesterContext<'a> {
             let result =
                 self.send_receive_spdm_key_exchange(slot_id, measurement_summary_hash_type);
             if let Ok(session_id) = result {
-                let result = self.send_receive_spdm_finish(session_id);
+                let result = self.send_receive_spdm_finish(slot_id, session_id);
                 if result.is_ok() {
                     Ok(session_id)
                 } else {

--- a/spdmlib/src/requester/psk_exchange_req.rs
+++ b/spdmlib/src/requester/psk_exchange_req.rs
@@ -138,9 +138,12 @@ impl<'a> RequesterContext<'a> {
                             .ok_or(spdm_err!(ENOMEM))?;
 
                         // create session - generate the handshake secret (including finished_key)
-                        let th1 = self
-                            .common
-                            .calc_req_transcript_hash(true, &message_k, None)?;
+                        let th1 = self.common.calc_req_transcript_hash(
+                            INVALID_SLOT,
+                            true,
+                            &message_k,
+                            None,
+                        )?;
                         debug!("!!! th1 : {:02x?}\n", th1.as_ref());
                         let base_hash_algo = self.common.negotiate_info.base_hash_sel;
                         let dhe_algo = self.common.negotiate_info.dhe_sel;
@@ -190,9 +193,12 @@ impl<'a> RequesterContext<'a> {
                             .unwrap();
 
                         // verify HMAC with finished_key
-                        let transcript_data = self
-                            .common
-                            .calc_req_transcript_data(true, &message_k, None)?;
+                        let transcript_data = self.common.calc_req_transcript_data(
+                            INVALID_SLOT,
+                            true,
+                            &message_k,
+                            None,
+                        )?;
                         let session = self
                             .common
                             .get_session_via_id(session_id)

--- a/spdmlib/src/requester/psk_finish_req.rs
+++ b/spdmlib/src/requester/psk_finish_req.rs
@@ -58,9 +58,12 @@ impl<'a> RequesterContext<'a> {
             .unwrap();
         let message_k = &session.runtime_info.message_k;
 
-        let transcript_data =
-            self.common
-                .calc_req_transcript_data(true, message_k, Some(&message_f))?;
+        let transcript_data = self.common.calc_req_transcript_data(
+            INVALID_SLOT,
+            true,
+            message_k,
+            Some(&message_f),
+        )?;
         let session = self.common.get_session_via_id(session_id).unwrap();
         let hmac = session.generate_hmac_with_request_finished_key(transcript_data.as_ref())?;
         message_f
@@ -101,6 +104,7 @@ impl<'a> RequesterContext<'a> {
                             .unwrap();
                         let message_k = &session.runtime_info.message_k; // generate the data secret
                         let th2 = self.common.calc_req_transcript_hash(
+                            INVALID_SLOT,
                             true,
                             message_k,
                             Some(&session.runtime_info.message_f),

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -192,11 +192,11 @@ fn test_spdm(
     if context
         .send_receive_spdm_measurement(
             None,
+            0,
             SpdmMeasurementeAttributes::SIGNATURE_REQUESTED,
             SpdmMeasurementOperation::SpdmMeasurementRequestAll,
             &mut total_number,
             &mut spdm_measurement_record_structure,
-            0,
         )
         .is_err()
     {
@@ -245,11 +245,11 @@ fn test_spdm(
         if context
             .send_receive_spdm_measurement(
                 Some(session_id),
+                0,
                 SpdmMeasurementeAttributes::SIGNATURE_REQUESTED,
                 SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber,
                 &mut total_number,
                 &mut spdm_measurement_record_structure,
-                0,
             )
             .is_err()
         {


### PR DESCRIPTION
1. change peer_cert_chain in struct SpdmPeerInfo to hold
[Option\<SpdmCertChain\>; 8] instread of SpdmCertChain

Signed-off-by: Longlong Yang <longlong.yang@intel.com>