### PR TITLE
Fix issues related to #276

### DIFF
--- a/fuzz-target/pass_context/src/pass_responder.rs
+++ b/fuzz-target/pass_context/src/pass_responder.rs
@@ -116,7 +116,7 @@ pub fn pass_rsp_handle_spdm_digest() {
         0, 0, 0, 0, 2, 32, 16, 0, 3, 32, 2, 0, 4, 32, 2, 0, 5, 32, 1, 0,
     ]);
 
-    context.handle_spdm_digest(&[17, 129, 0, 0]);
+    context.handle_spdm_digest(&[17, 129, 0, 0], None);
     let mut req_buf = [0u8; 1024];
     socket_io_transport.receive(&mut req_buf, 60).unwrap();
     println!("Received: {:?}", req_buf);
@@ -146,8 +146,8 @@ pub fn pass_rsp_handle_spdm_certificate() {
         17, 227, 4, 0, 48, 0, 1, 0, 128, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 2, 32, 16, 0, 3, 32, 2, 0, 4, 32, 2, 0, 5, 32, 1, 0,
     ]);
-    context.handle_spdm_digest(&[17, 129, 0, 0]);
-    context.handle_spdm_certificate(&[17, 130, 0, 0, 0, 0, 0, 2]);
+    context.handle_spdm_digest(&[17, 129, 0, 0], None);
+    context.handle_spdm_certificate(&[17, 130, 0, 0, 0, 0, 0, 2], None);
     let mut req_buf = [0u8; 1024];
     socket_io_transport.receive(&mut req_buf, 60).unwrap();
     println!("Received: {:?}", req_buf);
@@ -177,8 +177,8 @@ pub fn pass_rsp_handle_spdm_challenge() {
         17, 227, 4, 0, 48, 0, 1, 0, 128, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 2, 32, 16, 0, 3, 32, 2, 0, 4, 32, 2, 0, 5, 32, 1, 0,
     ]);
-    context.handle_spdm_digest(&[17, 129, 0, 0]);
-    context.handle_spdm_certificate(&[17, 130, 0, 0, 0, 0, 0, 2]);
+    context.handle_spdm_digest(&[17, 129, 0, 0], None);
+    context.handle_spdm_certificate(&[17, 130, 0, 0, 0, 0, 0, 2], None);
     context.handle_spdm_challenge(&[
         17, 131, 0, 0, 96, 98, 50, 80, 166, 189, 68, 2, 27, 142, 255, 200, 180, 230, 76, 45, 12,
         178, 253, 70, 242, 202, 83, 171, 115, 148, 32, 249, 52, 170, 141, 122,
@@ -212,8 +212,8 @@ pub fn pass_rsp_handle_spdm_measurement() {
         17, 227, 4, 0, 48, 0, 1, 0, 128, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 2, 32, 16, 0, 3, 32, 2, 0, 4, 32, 2, 0, 5, 32, 1, 0,
     ]);
-    context.handle_spdm_digest(&[17, 129, 0, 0]);
-    context.handle_spdm_certificate(&[17, 130, 0, 0, 0, 0, 0, 2]);
+    context.handle_spdm_digest(&[17, 129, 0, 0], None);
+    context.handle_spdm_certificate(&[17, 130, 0, 0, 0, 0, 0, 2], None);
     context.handle_spdm_challenge(&[
         17, 131, 0, 0, 96, 98, 50, 80, 166, 189, 68, 2, 27, 142, 255, 200, 180, 230, 76, 45, 12,
         178, 253, 70, 242, 202, 83, 171, 115, 148, 32, 249, 52, 170, 141, 122,
@@ -249,8 +249,8 @@ pub fn pass_rsp_handle_spdm_key_exchange() {
         17, 227, 4, 0, 48, 0, 1, 0, 128, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 2, 32, 16, 0, 3, 32, 2, 0, 4, 32, 2, 0, 5, 32, 1, 0,
     ]);
-    context.handle_spdm_digest(&[17, 129, 0, 0]);
-    context.handle_spdm_certificate(&[17, 130, 0, 0, 0, 0, 0, 2]);
+    context.handle_spdm_digest(&[17, 129, 0, 0], None);
+    context.handle_spdm_certificate(&[17, 130, 0, 0, 0, 0, 0, 2], None);
     context.handle_spdm_challenge(&[
         17, 131, 0, 0, 96, 98, 50, 80, 166, 189, 68, 2, 27, 142, 255, 200, 180, 230, 76, 45, 12,
         178, 253, 70, 242, 202, 83, 171, 115, 148, 32, 249, 52, 170, 141, 122,
@@ -295,8 +295,8 @@ pub fn pass_rsp_handle_spdm_psk_exchange() {
         17, 227, 4, 0, 48, 0, 1, 0, 128, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 2, 32, 16, 0, 3, 32, 2, 0, 4, 32, 2, 0, 5, 32, 1, 0,
     ]);
-    context.handle_spdm_digest(&[17, 129, 0, 0]);
-    context.handle_spdm_certificate(&[17, 130, 0, 0, 0, 0, 0, 2]);
+    context.handle_spdm_digest(&[17, 129, 0, 0], None);
+    context.handle_spdm_certificate(&[17, 130, 0, 0, 0, 0, 0, 2], None);
     context.handle_spdm_challenge(&[
         17, 131, 0, 0, 96, 98, 50, 80, 166, 189, 68, 2, 27, 142, 255, 200, 180, 230, 76, 45, 12,
         178, 253, 70, 242, 202, 83, 171, 115, 148, 32, 249, 52, 170, 141, 122,

--- a/fuzz-target/responder/certificate_rsp/src/main.rs
+++ b/fuzz-target/responder/certificate_rsp/src/main.rs
@@ -27,7 +27,7 @@ fn fuzz_handle_spdm_certificate(data: &[u8]) {
     );
 
     context.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
-    context.handle_spdm_certificate(data);
+    context.handle_spdm_certificate(data, None);
 }
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]

--- a/fuzz-target/responder/digest_rsp/src/main.rs
+++ b/fuzz-target/responder/digest_rsp/src/main.rs
@@ -31,7 +31,7 @@ fn fuzz_handle_spdm_digest(data: &[u8]) {
         data: [0u8; config::MAX_SPDM_CERT_CHAIN_DATA_SIZE],
     });
     context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
-    context.handle_spdm_digest(data);
+    context.handle_spdm_digest(data, None);
 }
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]

--- a/fuzz-target/responder/end_session_rsp/src/main.rs
+++ b/fuzz-target/responder/end_session_rsp/src/main.rs
@@ -43,7 +43,7 @@ fn fuzz_handle_spdm_end_session(data: &[u8]) {
 
     context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 
-    context.handle_spdm_end_session(4294901758, data);
+    let _ = context.handle_spdm_end_session(4294901758, data);
 }
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]

--- a/spdmlib/src/responder/certificate_rsp.rs
+++ b/spdmlib/src/responder/certificate_rsp.rs
@@ -7,14 +7,14 @@ use crate::message::*;
 use crate::responder::*;
 
 impl<'a> ResponderContext<'a> {
-    pub fn handle_spdm_certificate(&mut self, bytes: &[u8]) {
+    pub fn handle_spdm_certificate(&mut self, bytes: &[u8], _session_id: Option<u32>) {
         let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
         let mut writer = Writer::init(&mut send_buffer);
         self.write_spdm_certificate_response(bytes, &mut writer);
         let _ = self.send_message(writer.used_slice());
     }
 
-    pub fn write_spdm_certificate_response(&mut self, bytes: &[u8], writer: &mut Writer) {
+    fn write_spdm_certificate_response(&mut self, bytes: &[u8], writer: &mut Writer) {
         let mut reader = Reader::init(bytes);
         SpdmMessageHeader::read(&mut reader);
 
@@ -134,7 +134,7 @@ mod tests_responder {
         let bytes = &mut [0u8; 1024];
         bytes.copy_from_slice(&spdm_message_header[0..]);
         bytes[2..].copy_from_slice(&capabilities[0..1022]);
-        context.handle_spdm_certificate(bytes);
+        context.handle_spdm_certificate(bytes, None);
 
         let data = context.common.runtime_info.message_b.as_ref();
         let u8_slice = &mut [0u8; 2048];

--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -149,8 +149,14 @@ impl<'a> ResponderContext<'a> {
                 SpdmRequestResponseCode::SpdmRequestGetVersion => false,
                 SpdmRequestResponseCode::SpdmRequestGetCapabilities => false,
                 SpdmRequestResponseCode::SpdmRequestNegotiateAlgorithms => false,
-                SpdmRequestResponseCode::SpdmRequestGetDigests => false,
-                SpdmRequestResponseCode::SpdmRequestGetCertificate => false,
+                SpdmRequestResponseCode::SpdmRequestGetDigests => {
+                    self.handle_spdm_digest(bytes, Some(session_id));
+                    true
+                }
+                SpdmRequestResponseCode::SpdmRequestGetCertificate => {
+                    self.handle_spdm_certificate(bytes, Some(session_id));
+                    true
+                }
                 SpdmRequestResponseCode::SpdmRequestChallenge => false,
                 SpdmRequestResponseCode::SpdmRequestGetMeasurements => {
                     self.handle_spdm_measurement(Some(session_id), bytes);
@@ -237,11 +243,11 @@ impl<'a> ResponderContext<'a> {
                     true
                 }
                 SpdmRequestResponseCode::SpdmRequestGetDigests => {
-                    self.handle_spdm_digest(bytes);
+                    self.handle_spdm_digest(bytes, None);
                     true
                 }
                 SpdmRequestResponseCode::SpdmRequestGetCertificate => {
-                    self.handle_spdm_certificate(bytes);
+                    self.handle_spdm_certificate(bytes, None);
                     true
                 }
                 SpdmRequestResponseCode::SpdmRequestChallenge => {

--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -182,7 +182,7 @@ impl<'a> ResponderContext<'a> {
                 }
 
                 SpdmRequestResponseCode::SpdmRequestEndSession => {
-                    self.handle_spdm_end_session(session_id, bytes);
+                    let _ = self.handle_spdm_end_session(session_id, bytes);
                     true
                 }
                 SpdmRequestResponseCode::SpdmRequestVendorDefinedRequest => {

--- a/spdmlib/src/responder/digest_rsp.rs
+++ b/spdmlib/src/responder/digest_rsp.rs
@@ -12,14 +12,14 @@ use crate::protocol::gen_array_clone;
 use alloc::boxed::Box;
 
 impl<'a> ResponderContext<'a> {
-    pub fn handle_spdm_digest(&mut self, bytes: &[u8]) {
+    pub fn handle_spdm_digest(&mut self, bytes: &[u8], _session_id: Option<u32>) {
         let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
         let mut writer = Writer::init(&mut send_buffer);
         self.write_spdm_digest_response(bytes, &mut writer);
         let _ = self.send_message(writer.used_slice());
     }
 
-    pub fn write_spdm_digest_response(&mut self, bytes: &[u8], writer: &mut Writer) {
+    fn write_spdm_digest_response(&mut self, bytes: &[u8], writer: &mut Writer) {
         let mut reader = Reader::init(bytes);
         SpdmMessageHeader::read(&mut reader);
 
@@ -122,6 +122,6 @@ mod tests_responder {
         value.encode(&mut writer);
 
         let bytes = &mut [0u8; 1024];
-        context.handle_spdm_digest(bytes);
+        context.handle_spdm_digest(bytes, None);
     }
 }

--- a/test/spdm-emu/src/secret_impl_sample.rs
+++ b/test/spdm-emu/src/secret_impl_sample.rs
@@ -251,7 +251,9 @@ fn spdm_measurement_collection_impl(
 
             let mut digest_value: [u8; config::MAX_SPDM_MEASUREMENT_VALUE_LEN] =
                 [0; config::MAX_SPDM_MEASUREMENT_VALUE_LEN];
-            digest_value.copy_from_slice(digest.data.as_ref());
+            digest_value[(measurement_index) * SPDM_MAX_HASH_SIZE
+                ..(measurement_index + 1) * SPDM_MAX_HASH_SIZE]
+                .copy_from_slice(digest.data.as_ref());
             Some(SpdmMeasurementRecordStructure {
                 number_of_blocks: 1,
                 record: [

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -296,20 +296,16 @@ pub fn send_unknown(
 
 pub fn send_stop(
     stream: &mut TcpStream,
-    transport_encap: &mut dyn SpdmTransportEncap,
+    _transport_encap: &mut dyn SpdmTransportEncap,
     transport_type: u32,
 ) {
     println!("get stop");
-
-    let mut payload = [0u8; 1024];
-
-    let used = transport_encap.encap(b"", &mut payload[..], false).unwrap();
 
     let _buffer_size = spdm_emu::spdm_emu::send_message(
         stream,
         transport_type,
         spdm_emu::spdm_emu::SOCKET_SPDM_COMMAND_STOP,
-        &payload[..used],
+        &[],
     );
 }
 


### PR DESCRIPTION
These patches fix a communication issue between the rust-spdm of spdm-responder-emu and the libspdm version of spdm_requester_emu #276. Fixed #277, #279, #280

**Note:** https://github.com/jyao1/rust-spdm/issues/278 issue is not resolved.This requires the libspdm's spdm_requester_emu to remove the do_app_session_via_spdm related code.

