### PR TITLE
ExportMasterSecret should derive from MasterSecret

### DIFF
--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -350,7 +350,7 @@ impl SpdmSession {
             self.key_schedule.derive_export_master_secret(
                 spdm_version,
                 hash_algo,
-                self.handshake_secret.export_master_secret.as_ref(),
+                self.master_secret.master_secret.as_ref(),
             ) {
             ems
         } else {


### PR DESCRIPTION
SPDM spec 1.2 Key schedule section says:

HKDF-Expand ( Master-Secret, bin_str8, Hash.Length ) = Export Master Secret.

This patch fix #290.

Signed-off-by: xiaoyuxlu <xiaoyu1.lu@intel.com>