### PR TITLE
CI/CD: run coverage when every tag created.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,9 @@
 name: Coverage
-on: [pull_request, push]
+on:
+  push:
+    # Pattern matched against refs/tags
+    tags:        
+      - '**'           # Push events to every tag including hierarchical tags like v0.1.0/beta
 env:
   AS: nasm
   AR_x86_64_unknown_uefi: llvm-ar


### PR DESCRIPTION
e.g. If we need to release version v0.1.0,
we create v0.1.0/alpha tag first. The coverage will be run. Then we need to check that the coverage will not decrease.
