### PR TITLE
Support hash update for fuzzy tests and add build scripts

### DIFF
--- a/fuzz-target/pass_context/src/pass_requester.rs
+++ b/fuzz-target/pass_context/src/pass_requester.rs
@@ -43,10 +43,7 @@ pub fn fuzz_total_requesters() {
         return;
     }
 
-    if requester
-        .send_receive_spdm_certificate(Some(session_id), 0)
-        .is_err()
-    {
+    if requester.send_receive_spdm_certificate(None, 0).is_err() {
         return;
     }
 

--- a/fuzz-target/requester/certificate_req/src/main.rs
+++ b/fuzz-target/requester/certificate_req/src/main.rs
@@ -38,6 +38,9 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         responder.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
 
+        responder.common.runtime_info.message_m =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
         let mut device_io_requester =
             fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
@@ -52,6 +55,9 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.base_asym_sel =
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
+
+        requester.common.runtime_info.message_m =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
 
         let _ = requester.send_receive_spdm_certificate(None, 0).is_err();
     }
@@ -76,6 +82,9 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         responder.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
 
+        responder.common.runtime_info.message_m =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
         let mut device_io_requester =
             fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
@@ -90,6 +99,9 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.base_asym_sel =
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
+
+        requester.common.runtime_info.message_m =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
 
         let _ = requester.send_receive_spdm_certificate(None, 0).is_err();
     }
@@ -113,6 +125,9 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         responder.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
 
+        responder.common.runtime_info.message_m =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
         let mut device_io_requester =
             fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
@@ -134,6 +149,9 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             .unwrap();
         tmp.data_size += 1;
         requester.common.provision_info.peer_cert_chain_data = Some(tmp);
+
+        requester.common.runtime_info.message_m =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
 
         let _ = requester.send_receive_spdm_certificate(None, 0).is_err();
     }
@@ -158,6 +176,8 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         responder.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
 
+        responder.common.runtime_info.message_m =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         // digest_rsp
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
@@ -180,6 +200,10 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.base_asym_sel =
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
+
+        requester.common.runtime_info.message_m =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         let _ = requester.send_receive_spdm_certificate(None, 0).is_err();
     }
     {
@@ -201,6 +225,9 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         responder.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
 
+        responder.common.runtime_info.message_m =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
         let mut device_io_requester =
             fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
@@ -214,6 +241,9 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.base_asym_sel =
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
+
+        requester.common.runtime_info.message_m =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         let _ = requester.send_receive_spdm_certificate(None, 0).is_err();
     }
 }

--- a/fuzz-target/requester/challenge_req/src/main.rs
+++ b/fuzz-target/requester/challenge_req/src/main.rs
@@ -34,6 +34,9 @@ fn fuzz_send_receive_spdm_challenge(fuzzdata: &[u8]) {
     responder.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
     responder.common.runtime_info.need_measurement_summary_hash = true;
 
+    responder.common.runtime_info.message_m =
+        spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
     let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
     let mut device_io_requester =
         fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
@@ -57,7 +60,8 @@ fn fuzz_send_receive_spdm_challenge(fuzzdata: &[u8]) {
     requester.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
     requester.common.runtime_info.need_measurement_summary_hash = true;
 
-    // requester.common.peer_info.peer_cert_chain.cert_chain = REQ_CERT_CHAIN_DATA;
+    requester.common.runtime_info.message_m =
+        spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
 
     let _ = requester
         .send_receive_spdm_challenge(

--- a/fuzz-target/requester/digest_req/src/main.rs
+++ b/fuzz-target/requester/digest_req/src/main.rs
@@ -30,6 +30,9 @@ fn fuzz_send_receive_spdm_digest(fuzzdata: &[u8]) {
     });
     responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
 
+    responder.common.runtime_info.message_m =
+        spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
     let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
     let mut device_io_requester =
         fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
@@ -42,6 +45,9 @@ fn fuzz_send_receive_spdm_digest(fuzzdata: &[u8]) {
     );
 
     requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
+
+    requester.common.runtime_info.message_m =
+        spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
 
     let _ = requester.send_receive_spdm_digest(None).is_err();
 }

--- a/fuzz-target/requester/finish_req/src/main.rs
+++ b/fuzz-target/requester/finish_req/src/main.rs
@@ -59,6 +59,14 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
             SpdmAeadAlgo::AES_256_GCM,
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        responder.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        responder.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         responder.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
@@ -101,6 +109,15 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
             SpdmAeadAlgo::AES_256_GCM,
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
+
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        requester.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        requester.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
         let _ = requester.send_receive_spdm_finish(0, 4294901758);
@@ -155,6 +172,15 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
             SpdmAeadAlgo::AES_256_GCM,
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
+
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        responder.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        responder.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         responder.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
@@ -195,10 +221,18 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
             SpdmAeadAlgo::AES_256_GCM,
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        requester.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        requester.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
         let _ = requester.send_receive_spdm_finish(0, 4294901758);
     }
+
     {
         let shared_buffer = SharedBuffer::new();
         let mut device_io_responder = FakeSpdmDeviceIoReceve::new(&shared_buffer);
@@ -241,6 +275,14 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
             SpdmAeadAlgo::AES_256_GCM,
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        responder.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        responder.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         responder.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
@@ -281,6 +323,14 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
             SpdmAeadAlgo::AES_256_GCM,
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        requester.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        requester.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
         let _ = requester.send_receive_spdm_finish(0, 4294901758);
@@ -306,19 +356,19 @@ fn main() {
     #[cfg(not(feature = "fuzz"))]
     {
         let args: Vec<String> = std::env::args().collect();
-        if args.len() < 2 {
-            // Here you can replace the single-step debugging value in the fuzzdata array.
-            let fuzzdata = [
-                0x1, 0x0, 0x2, 0x0, 0x9, 0x0, 0x0, 0x0, 0xfe, 0xff, 0xfe, 0xff, 0x16, 0x0, 0xca,
-                0xa7, 0x51, 0x58, 0x4d, 0x60, 0xe6, 0xc5, 0x74, 0x1c, 0xb3, 0xae, 0xaf, 0x62, 0x4b,
-                0x2e, 0x49, 0x54, 0x7a, 0x75, 0x86, 0x37,
-            ];
-            fuzz_send_receive_spdm_finish(&fuzzdata);
-        } else {
-            let path = &args[1];
-            let data = std::fs::read(path).expect("read crash file fail");
-            fuzz_send_receive_spdm_finish(data.as_slice());
-        }
+        // if args.len() < 2 {
+        //     // Here you can replace the single-step debugging value in the fuzzdata array.
+        //     let fuzzdata = [
+        //         0x1, 0x0, 0x2, 0x0, 0x9, 0x0, 0x0, 0x0, 0xfe, 0xff, 0xfe, 0xff, 0x16, 0x0, 0xca,
+        //         0xa7, 0x51, 0x58, 0x4d, 0x60, 0xe6, 0xc5, 0x74, 0x1c, 0xb3, 0xae, 0xaf, 0x62, 0x4b,
+        //         0x2e, 0x49, 0x54, 0x7a, 0x75, 0x86, 0x37,
+        //     ];
+        // fuzz_send_receive_spdm_finish(&fuzzdata);
+        // } else {
+        let path = "/home/xiaoyu/firmware.security.tdx.tpa.td/rust-spdm/fuzz-target/in/finish_req/default.raw";
+        let data = std::fs::read(path).expect("read crash file fail");
+        fuzz_send_receive_spdm_finish(data.as_slice());
+        // }
     }
     #[cfg(feature = "fuzz")]
     afl::fuzz!(|data: &[u8]| {

--- a/fuzz-target/requester/psk_finish_req/src/main.rs
+++ b/fuzz-target/requester/psk_finish_req/src/main.rs
@@ -41,6 +41,14 @@ fn fuzz_send_receive_spdm_psk_finish(fuzzdata: &[u8]) {
         SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
     );
 
+    let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+    dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+    responder.common.session[0]
+        .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+        .unwrap();
+    responder.common.session[0].runtime_info.message_k =
+        spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
     let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
     let mut device_io_requester =
         fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
@@ -67,6 +75,15 @@ fn fuzz_send_receive_spdm_psk_finish(fuzzdata: &[u8]) {
         SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
     );
     requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
+
+    let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+    dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+    requester.common.session[0]
+        .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+        .unwrap();
+    requester.common.session[0].runtime_info.message_k =
+        spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
     let _ = requester.send_receive_spdm_psk_finish(4294901758);
 }
 

--- a/fuzz-target/responder/certificate_rsp/src/main.rs
+++ b/fuzz-target/responder/certificate_rsp/src/main.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use fuzzlib::*;
-// use crate::spdmlib::message::capability::*;
+use spdmlib::protocol::SpdmBaseHashAlgo;
 
 fn fuzz_handle_spdm_certificate(data: &[u8]) {
     let (config_info, provision_info) = rsp_create_info();
@@ -27,6 +27,10 @@ fn fuzz_handle_spdm_certificate(data: &[u8]) {
     );
 
     context.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
+
+    context.common.runtime_info.message_m =
+        spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
     context.handle_spdm_certificate(data, None);
 }
 fn main() {

--- a/fuzz-target/responder/challenge_rsp/src/main.rs
+++ b/fuzz-target/responder/challenge_rsp/src/main.rs
@@ -29,7 +29,8 @@ fn fuzz_handle_spdm_challenge(data: &[u8]) {
     context.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
     context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
     context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
-
+    context.common.runtime_info.message_m =
+        spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
     context.handle_spdm_challenge(data);
 }
 fn main() {

--- a/fuzz-target/responder/digest_rsp/src/main.rs
+++ b/fuzz-target/responder/digest_rsp/src/main.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-use fuzzlib::*;
+use fuzzlib::{spdmlib::crypto, *};
 use spdmlib::protocol::*;
 
 fn fuzz_handle_spdm_digest(data: &[u8]) {
@@ -31,6 +31,8 @@ fn fuzz_handle_spdm_digest(data: &[u8]) {
         data: [0u8; config::MAX_SPDM_CERT_CHAIN_DATA_SIZE],
     });
     context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
+    context.common.runtime_info.message_m =
+        spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
     context.handle_spdm_digest(data, None);
 }
 fn main() {

--- a/fuzz-target/responder/finish_rsp/src/main.rs
+++ b/fuzz-target/responder/finish_rsp/src/main.rs
@@ -52,6 +52,13 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
         context.common.negotiate_info.rsp_capabilities_sel =
             SpdmResponseCapabilityFlags::HANDSHAKE_IN_THE_CLEAR_CAP;
 
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        context.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        context.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 
         context.handle_spdm_finish(4294901758, data);
@@ -84,6 +91,15 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
         context.common.provision_info.my_cert_chain_data = None;
+
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        context.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        context.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
         context.handle_spdm_finish(4294901758, data);
@@ -116,6 +132,14 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
 
         context.common.negotiate_info.rsp_capabilities_sel =
             SpdmResponseCapabilityFlags::HANDSHAKE_IN_THE_CLEAR_CAP;
+
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        context.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        context.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
 
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
         context.handle_spdm_finish(4294901758, data);
@@ -151,6 +175,14 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
 
         context.common.negotiate_info.rsp_capabilities_sel =
             SpdmResponseCapabilityFlags::HANDSHAKE_IN_THE_CLEAR_CAP;
+
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        context.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        context.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
 
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
@@ -189,6 +221,14 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
             SpdmResponseCapabilityFlags::HANDSHAKE_IN_THE_CLEAR_CAP;
 
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
+
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        context.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        context.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
 
         context
             .common
@@ -231,6 +271,14 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
             .append_message(&[1u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE - 103]);
         context.common.negotiate_info.rsp_capabilities_sel =
             SpdmResponseCapabilityFlags::HANDSHAKE_IN_THE_CLEAR_CAP;
+
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        context.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        context.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
 
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 

--- a/fuzz-target/responder/measurement_rsp/src/main.rs
+++ b/fuzz-target/responder/measurement_rsp/src/main.rs
@@ -32,6 +32,9 @@ fn fuzz_handle_spdm_measurement(data: &[u8]) {
     context.common.negotiate_info.measurement_specification_sel =
         SpdmMeasurementSpecification::DMTF;
 
+    context.common.runtime_info.message_m =
+        spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
     context.handle_spdm_measurement(None, data);
 }
 fn main() {

--- a/fuzz-target/responder/psk_finish_rsp/src/main.rs
+++ b/fuzz-target/responder/psk_finish_rsp/src/main.rs
@@ -48,6 +48,14 @@ fn fuzz_handle_spdm_psk_finish(data: &[u8]) {
         );
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        context.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        context.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         context.handle_spdm_psk_finish(4294901758, data);
     }
 
@@ -79,6 +87,15 @@ fn fuzz_handle_spdm_psk_finish(data: &[u8]) {
             .message_a
             .append_message(&[1u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE]);
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
+
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        context.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        context.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         context.handle_spdm_psk_finish(4294901758, data);
     }
     {
@@ -104,6 +121,15 @@ fn fuzz_handle_spdm_psk_finish(data: &[u8]) {
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
+
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        context.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        context.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+
         context.handle_spdm_psk_finish(4294901758, data);
     }
     {
@@ -130,6 +156,14 @@ fn fuzz_handle_spdm_psk_finish(data: &[u8]) {
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
+
+        let mut dhe_secret = SpdmDheFinalKeyStruct::default();
+        dhe_secret.data_size = SpdmDheAlgo::SECP_384_R1.get_size();
+        context.common.session[0]
+            .set_dhe_secret(SpdmVersion::SpdmVersion12, dhe_secret)
+            .unwrap();
+        context.common.session[0].runtime_info.message_k =
+            spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
 
         context.handle_spdm_psk_finish(4294901758, data);
     }

--- a/spdmlib/build.rs
+++ b/spdmlib/build.rs
@@ -194,7 +194,7 @@ fn main() {
     .expect("Failed to generate configuration code from the template and JSON config");
 
     let dest_path = Path::new(SPDM_CONFIG_RS_OUT_DIR).join(SPDM_CONFIG_RS_OUT_FILE_NAME);
-    fs::write(&dest_path, to_generate).unwrap();
+    fs::write(dest_path, to_generate).unwrap();
 
     // Re-run the build script if the files at the given paths or envs have changed.
     println!("cargo:rerun-if-changed=build.rs");

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -476,7 +476,7 @@ impl ManagedBuffer {
 
 impl AsRef<[u8]> for ManagedBuffer {
     fn as_ref(&self) -> &[u8] {
-        &self.1[0..(self.0 as usize)]
+        &self.1[0..self.0]
     }
 }
 

--- a/spdmlib/src/common/opaque.rs
+++ b/spdmlib/src/common/opaque.rs
@@ -530,6 +530,6 @@ impl Codec for SpdmOpaqueSupport {
 
 impl SpdmOpaqueSupport {
     pub fn is_no_more_than_one_selected(&self) -> bool {
-        return self.bits() == 0 || (self.bits() & self.bits() - 1 == 0);
+        self.bits() == 0 || self.bits() & (self.bits() - 1) == 0
     }
 }

--- a/spdmlib/src/common/opaque.rs
+++ b/spdmlib/src/common/opaque.rs
@@ -527,3 +527,9 @@ impl Codec for SpdmOpaqueSupport {
         SpdmOpaqueSupport::from_bits(bits)
     }
 }
+
+impl SpdmOpaqueSupport {
+    pub fn is_no_more_than_one_selected(&self) -> bool {
+        return self.bits() == 0 || (self.bits() & self.bits() - 1 == 0);
+    }
+}

--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -965,7 +965,7 @@ impl SpdmSession {
         //debug!("secure_buffer len - {}\n", secured_buffer.len());
 
         // secure buffer might be bigger for alignment
-        if secured_buffer.len() < length as usize + aad_size as usize {
+        if secured_buffer.len() < length as usize + aad_size {
             return spdm_result_err!(EINVAL);
         }
 

--- a/spdmlib/src/common/spdm_codec.rs
+++ b/spdmlib/src/common/spdm_codec.rs
@@ -77,7 +77,7 @@ impl SpdmCodec for SpdmSignatureStruct {
 }
 impl SpdmCodec for SpdmCertChain {
     fn spdm_encode(&self, context: &mut SpdmContext, bytes: &mut Writer) {
-        let length = self.cert_chain.data_size as u16 + self.root_hash.data_size as u16 + 4_u16;
+        let length = self.cert_chain.data_size + self.root_hash.data_size + 4_u16;
         length.encode(bytes);
         0u16.encode(bytes);
 
@@ -96,7 +96,7 @@ impl SpdmCodec for SpdmCertChain {
         let length = u16::read(r)?;
         u16::read(r)?;
         let root_hash = SpdmDigestStruct::spdm_read(context, r)?;
-        let data_size = length - 4 - root_hash.data_size as u16;
+        let data_size = length - 4 - root_hash.data_size;
         let mut cert_chain = SpdmCertChainData {
             data_size,
             ..Default::default()

--- a/spdmlib/src/crypto/spdm_ring/aead_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/aead_impl.rs
@@ -43,7 +43,7 @@ fn encrypt(
     }
     let plain_text_size = plain_text.len();
 
-    if cipher_text.len() != plain_text_size as usize {
+    if cipher_text.len() != plain_text_size {
         panic!("cipher_text len invalid");
     }
 
@@ -108,7 +108,7 @@ fn decrypt(
     }
     let cipher_text_size = cipher_text.len();
 
-    if plain_text.len() != cipher_text_size as usize {
+    if plain_text.len() != cipher_text_size {
         panic!("plain_text len invalid");
     }
 

--- a/spdmlib/src/crypto/spdm_ring/hkdf_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/hkdf_impl.rs
@@ -32,7 +32,7 @@ fn hkdf_expand(
     let res = pkr
         .expand(&[info], SpdmCryptoHkdfKeyLen::new(out_size))
         .and_then(|okm| {
-            let len = out_size as u16;
+            let len = out_size;
             ret.data_size = len;
             okm.fill(&mut ret.data[..len as usize])
         });

--- a/spdmlib/src/message/algorithm.rs
+++ b/spdmlib/src/message/algorithm.rs
@@ -398,7 +398,11 @@ mod tests {
 
         let transport_encap = &mut TransportEncap {};
         let device_io = &mut DeviceIO {};
-        let config_info = SpdmConfigInfo::default();
+        let mut config_info = SpdmConfigInfo::default();
+        config_info.measurement_specification = SpdmMeasurementSpecification::DMTF;
+        config_info.measurement_hash_algo = SpdmMeasurementHashAlgo::RAW_BIT_STREAM;
+        config_info.base_asym_algo = SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048;
+        config_info.base_hash_algo = SpdmBaseHashAlgo::TPM_ALG_SHA_256;
         let provision_info = SpdmProvisionInfo::default();
         let mut context = SpdmContext::new(device_io, transport_encap, config_info, provision_info);
 

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -719,6 +719,11 @@ mod tests {
         };
         create_spdm_context!(context);
 
+        context.config_info.measurement_specification = SpdmMeasurementSpecification::DMTF;
+        context.config_info.measurement_hash_algo = SpdmMeasurementHashAlgo::RAW_BIT_STREAM;
+        context.config_info.base_asym_algo = SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048;
+        context.config_info.base_hash_algo = SpdmBaseHashAlgo::TPM_ALG_SHA_256;
+
         let spdm_message = new_spdm_message(value, context);
         assert_eq!(
             spdm_message.header.request_response_code,

--- a/spdmlib/src/protocol/algo.rs
+++ b/spdmlib/src/protocol/algo.rs
@@ -636,7 +636,7 @@ impl Codec for SpdmAlgStruct {
         let alg_type = SpdmAlgType::read(r)?;
         let alg_count = u8::read(r)?;
         let alg_fixed_count = ((alg_count as u32 >> 4) & 0xF) as u8;
-        let alg_ext_count = (alg_count & 0xF) as u8;
+        let alg_ext_count = alg_count & 0xF;
 
         let alg_supported = match alg_type {
             SpdmAlgType::SpdmAlgTypeDHE => Some(SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::read(r)?)),

--- a/spdmlib/src/protocol/algo.rs
+++ b/spdmlib/src/protocol/algo.rs
@@ -128,6 +128,10 @@ impl SpdmMeasurementSpecification {
             }
         }
     }
+
+    pub fn is_no_more_than_one_selected(&self) -> bool {
+        return self.bits() == 0 || (self.bits() & self.bits() - 1 == 0);
+    }
 }
 
 bitflags! {
@@ -157,6 +161,12 @@ impl SpdmMeasurementHashAlgo {
                 panic!("invalid MeasurementHashAlgo");
             }
         }
+    }
+
+    /// return true if no more than one is selected
+    /// return false if two or more is selected
+    pub fn is_no_more_than_one_selected(&self) -> bool {
+        return self.bits() == 0 || (self.bits() & self.bits() - 1 == 0);
     }
 }
 impl Codec for SpdmMeasurementHashAlgo {
@@ -223,6 +233,12 @@ impl SpdmBaseAsymAlgo {
             }
         }
     }
+
+    /// return true if no more than one is selected
+    /// return false if two or more is selected
+    pub fn is_no_more_than_one_selected(&self) -> bool {
+        return self.bits() == 0 || (self.bits() & self.bits() - 1 == 0);
+    }
 }
 
 impl Codec for SpdmBaseAsymAlgo {
@@ -277,6 +293,12 @@ impl SpdmBaseHashAlgo {
                 panic!("invalid HashAlgo");
             }
         }
+    }
+
+    /// return true if no more than one is selected
+    /// return false if two or more is selected
+    pub fn is_no_more_than_one_selected(&self) -> bool {
+        return self.bits() == 0 || (self.bits() & self.bits() - 1 == 0);
     }
 }
 

--- a/spdmlib/src/protocol/algo.rs
+++ b/spdmlib/src/protocol/algo.rs
@@ -130,7 +130,7 @@ impl SpdmMeasurementSpecification {
     }
 
     pub fn is_no_more_than_one_selected(&self) -> bool {
-        return self.bits() == 0 || (self.bits() & self.bits() - 1 == 0);
+        self.bits() == 0 || self.bits() & (self.bits() - 1) == 0
     }
 }
 
@@ -166,7 +166,7 @@ impl SpdmMeasurementHashAlgo {
     /// return true if no more than one is selected
     /// return false if two or more is selected
     pub fn is_no_more_than_one_selected(&self) -> bool {
-        return self.bits() == 0 || (self.bits() & self.bits() - 1 == 0);
+        self.bits() == 0 || self.bits() & (self.bits() - 1) == 0
     }
 }
 impl Codec for SpdmMeasurementHashAlgo {
@@ -237,7 +237,7 @@ impl SpdmBaseAsymAlgo {
     /// return true if no more than one is selected
     /// return false if two or more is selected
     pub fn is_no_more_than_one_selected(&self) -> bool {
-        return self.bits() == 0 || (self.bits() & self.bits() - 1 == 0);
+        self.bits() == 0 || self.bits() & (self.bits() - 1) == 0
     }
 }
 
@@ -298,7 +298,7 @@ impl SpdmBaseHashAlgo {
     /// return true if no more than one is selected
     /// return false if two or more is selected
     pub fn is_no_more_than_one_selected(&self) -> bool {
-        return self.bits() == 0 || (self.bits() & self.bits() - 1 == 0);
+        self.bits() == 0 || self.bits() & (self.bits() - 1) == 0
     }
 }
 

--- a/spdmlib/src/requester/negotiate_algorithms_req.rs
+++ b/spdmlib/src/requester/negotiate_algorithms_req.rs
@@ -97,7 +97,13 @@ impl<'a> RequesterContext<'a> {
 
                         self.common.negotiate_info.measurement_hash_sel =
                             algorithms.measurement_hash_algo;
+                        if algorithms.base_hash_sel.bits() == 0 {
+                            return spdm_result_err!(EINVAL);
+                        }
                         self.common.negotiate_info.base_hash_sel = algorithms.base_hash_sel;
+                        if algorithms.base_asym_sel.bits() == 0 {
+                            return spdm_result_err!(EINVAL);
+                        }
                         self.common.negotiate_info.base_asym_sel = algorithms.base_asym_sel;
                         for alg in algorithms
                             .alg_struct

--- a/spdmlib/src/responder/certificate_rsp.rs
+++ b/spdmlib/src/responder/certificate_rsp.rs
@@ -68,7 +68,7 @@ impl<'a> ResponderContext<'a> {
             length = my_cert_chain.data_size - offset;
         }
 
-        let portion_length = length as u16;
+        let portion_length = length;
         let remainder_length = my_cert_chain.data_size - (length + offset);
 
         let cert_chain_data =

--- a/spdmlib/src/responder/digest_rsp.rs
+++ b/spdmlib/src/responder/digest_rsp.rs
@@ -63,7 +63,7 @@ impl<'a> ResponderContext<'a> {
                 slot_count: 1u8,
                 digests: gen_array_clone(
                     SpdmDigestStruct {
-                        data_size: digest_size as u16,
+                        data_size: digest_size,
                         data: Box::new([0xffu8; SPDM_MAX_HASH_SIZE]),
                     },
                     SPDM_MAX_SLOT_NUMBER,

--- a/spdmlib/src/responder/measurement_rsp.rs
+++ b/spdmlib/src/responder/measurement_rsp.rs
@@ -153,7 +153,7 @@ impl<'a> ResponderContext<'a> {
                         data: [0u8; config::MAX_SPDM_OPAQUE_SIZE],
                     },
                     signature: SpdmSignatureStruct {
-                        data_size: signature_size as u16,
+                        data_size: signature_size,
                         data: [0x60u8; SPDM_MAX_ASYM_KEY_SIZE],
                     },
                 },

--- a/spdmlib_crypto_mbedtls/src/lib.rs
+++ b/spdmlib_crypto_mbedtls/src/lib.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #![cfg_attr(not(test), no_std)]
-#![feature(core_ffi_c)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Fix #321 

- Add build script sh_script/build.sh
  1. Run check only
      ./sh_script/build.sh -c
  2. Build rust-spdm
      ./sh_script/build.sh
  3. Build and run tests
      ./sh_script/build.sh -r
- Fix cargo clippy issue
- Add hash-update for fuzzy tests
