### PR TITLE
Test: Fix algorithm test issue.

### DIFF
--- a/spdmlib/src/message/algorithm.rs
+++ b/spdmlib/src/message/algorithm.rs
@@ -382,6 +382,11 @@ mod tests {
         let provision_info = SpdmProvisionInfo::default();
         let mut context = SpdmContext::new(device_io, transport_encap, config_info, provision_info);
 
+        context.config_info.measurement_specification = SpdmMeasurementSpecification::DMTF;
+        context.config_info.measurement_hash_algo = SpdmMeasurementHashAlgo::RAW_BIT_STREAM;
+        context.config_info.base_asym_algo = SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048;
+        context.config_info.base_hash_algo = SpdmBaseHashAlgo::TPM_ALG_SHA_256;
+
         value.spdm_encode(&mut context, &mut writer);
         let mut reader = Reader::init(u8_slice);
         assert_eq!(50, reader.left());

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -719,6 +719,11 @@ mod tests {
         };
         create_spdm_context!(context);
 
+        context.config_info.measurement_specification = SpdmMeasurementSpecification::DMTF;
+        context.config_info.measurement_hash_algo = SpdmMeasurementHashAlgo::RAW_BIT_STREAM;
+        context.config_info.base_asym_algo = SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048;
+        context.config_info.base_hash_algo = SpdmBaseHashAlgo::TPM_ALG_SHA_256;
+
         let spdm_message = new_spdm_message(value, context);
         assert_eq!(
             spdm_message.header.request_response_code,


### PR DESCRIPTION
REF: #320 

When config info is the default, the following checkpoint should fail. But these checkpoints were successful.

```
assert_eq!(
    payload.measurement_specification_sel,
    SpdmMeasurementSpecification::DMTF
);
assert_eq!(
    payload.measurement_hash_algo,
    SpdmMeasurementHashAlgo::RAW_BIT_STREAM
);
assert_eq!(payload.base_asym_sel, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048);
assert_eq!(payload.base_hash_sel, SpdmBaseHashAlgo::TPM_ALG_SHA_256);
```

Fix these checkpoints by adding corresponding config.
