### PR TITLE
CI/CD: Force install the specific version of afl

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args:  --force afl
+          args:  --force --version 0.12.12 afl
         if: runner.os == 'Linux'
 
       - name: Install Cargo-Fuzz (Linux)


### PR DESCRIPTION
rust version for rust-spdm is specific.
cargo install --force afl will always install a latest version of AFL. It may cause problem. Eg:
AFL LLVM runtime is not built with Rust rustc-1.65.0-nightly-d394408, run `cargo install --force afl` to build it.
