### PR TITLE
pass cross-testing with spdm-emu v2.2.0 using hash update.

### DIFF
--- a/spdmlib/src/protocol/capability.rs
+++ b/spdmlib/src/protocol/capability.rs
@@ -16,6 +16,7 @@ bitflags! {
         const KEY_UPD_CAP = 0b0100_0000_0000_0000;
         const HANDSHAKE_IN_THE_CLEAR_CAP = 0b1000_0000_0000_0000;
         const PUB_KEY_ID_CAP = 0b0000_0001_0000_0000_0000_0000;
+        const CHUNK_CAP = 0b0000_0010_0000_0000_0000_0000;
     }
 }
 

--- a/spdmlib/src/responder/measurement_rsp.rs
+++ b/spdmlib/src/responder/measurement_rsp.rs
@@ -116,6 +116,7 @@ impl<'a> ResponderContext<'a> {
             get_measurements.measurement_operation
         {
             if index > real_measurement_block_count {
+                self.write_spdm_error(SpdmErrorCode::SpdmErrorInvalidRequest, 0, writer);
                 return;
             }
             spdm_measurement_collection(


### PR DESCRIPTION
1. requester from rust-spdm <-> responder from spdm-emu
2. responder from rust-spdm <-> requester from spdm-emu
3. requester from rust-spdm <-> responder from rust-spdm

Signed-off-by: Yang Longlong <longlong.yang@intel.com>