### PR TITLE
Fuzzing: Fix AFL version problem.

### DIFF
--- a/fuzz-target/fuzzlib/Cargo.toml
+++ b/fuzz-target/fuzzlib/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-afl = "*"
+afl = "=0.12.12"
 spdm-emu = { path = "../../test/spdm-emu", default-features = false }
 spdmlib = { path = "../../spdmlib", default-features = false, features=["spdm-ring"] }
 codec = { path = "../../codec" }

--- a/fuzz-target/requester/algorithm_req/Cargo.toml
+++ b/fuzz-target/requester/algorithm_req/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/requester/capability_req/Cargo.toml
+++ b/fuzz-target/requester/capability_req/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/requester/certificate_req/Cargo.toml
+++ b/fuzz-target/requester/certificate_req/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 fuzzlib = { path = "../../fuzzlib", default-features = false }
 log = "0.4.13"
 simple_logger = "1.11.0"
-afl = {version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/requester/challenge_req/Cargo.toml
+++ b/fuzz-target/requester/challenge_req/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
 rand = "0.8.4"
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/requester/digest_req/Cargo.toml
+++ b/fuzz-target/requester/digest_req/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/requester/end_session_req/Cargo.toml
+++ b/fuzz-target/requester/end_session_req/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/requester/finish_req/Cargo.toml
+++ b/fuzz-target/requester/finish_req/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = {version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/requester/heartbeat_req/Cargo.toml
+++ b/fuzz-target/requester/heartbeat_req/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/requester/key_exchange_req/Cargo.toml
+++ b/fuzz-target/requester/key_exchange_req/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/requester/key_update_req/Cargo.toml
+++ b/fuzz-target/requester/key_update_req/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlog = []

--- a/fuzz-target/requester/measurement_req/Cargo.toml
+++ b/fuzz-target/requester/measurement_req/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/requester/psk_exchange_req/Cargo.toml
+++ b/fuzz-target/requester/psk_exchange_req/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/requester/psk_finish_req/Cargo.toml
+++ b/fuzz-target/requester/psk_finish_req/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/requester/version_req/Cargo.toml
+++ b/fuzz-target/requester/version_req/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/responder/algorithm_rsp/Cargo.toml
+++ b/fuzz-target/responder/algorithm_rsp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/responder/capability_rsp/Cargo.toml
+++ b/fuzz-target/responder/capability_rsp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/responder/certificate_rsp/Cargo.toml
+++ b/fuzz-target/responder/certificate_rsp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/responder/challenge_rsp/Cargo.toml
+++ b/fuzz-target/responder/challenge_rsp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/responder/digest_rsp/Cargo.toml
+++ b/fuzz-target/responder/digest_rsp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/responder/end_session_rsp/Cargo.toml
+++ b/fuzz-target/responder/end_session_rsp/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/responder/finish_rsp/Cargo.toml
+++ b/fuzz-target/responder/finish_rsp/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/responder/heartbeat_rsp/Cargo.toml
+++ b/fuzz-target/responder/heartbeat_rsp/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/responder/key_update_rsp/Cargo.toml
+++ b/fuzz-target/responder/key_update_rsp/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/responder/keyexchange_rsp/Cargo.toml
+++ b/fuzz-target/responder/keyexchange_rsp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/responder/measurement_rsp/Cargo.toml
+++ b/fuzz-target/responder/measurement_rsp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/responder/psk_finish_rsp/Cargo.toml
+++ b/fuzz-target/responder/psk_finish_rsp/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 default = ["hashed-transcript-data"]

--- a/fuzz-target/responder/pskexchange_rsp/Cargo.toml
+++ b/fuzz-target/responder/pskexchange_rsp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []

--- a/fuzz-target/responder/version_rsp/Cargo.toml
+++ b/fuzz-target/responder/version_rsp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-afl = { version = "*", optional = true }
+afl = { version = "=0.12.12", optional = true }
 
 [features]
 fuzzlogfile = []


### PR DESCRIPTION
Fix CI error:
error: failed to run custom build command for `afl v0.12.14`
Error: failed to run custom build command for `afl v0.12.14`
Caused by:
  process didn't exit successfully: `/home/runner/work/rust-spdm/rust-spdm/target/debug/build/afl-7c10dbd9de693d33/build-script-build` (signal: 4, SIGILL: illegal instruction)