### PR TITLE
Remove 2 mutable refs from SpdmConext and update the Spdm emulators

### DIFF
--- a/fuzz-target/requester/algorithm_req/src/main.rs
+++ b/fuzz-target/requester/algorithm_req/src/main.rs
@@ -17,25 +17,21 @@ fn fuzz_send_receive_spdm_algorithm(fuzzdata: &[u8]) {
 
     spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-    let mut responder = responder::ResponderContext::new(
-        &mut device_io_responder,
-        pcidoe_transport_encap,
-        rsp_config_info,
-        rsp_provision_info,
-    );
+    let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
     let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-    let mut device_io_requester =
-        fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-    let mut requester = requester::RequesterContext::new(
-        &mut device_io_requester,
-        pcidoe_transport_encap2,
-        req_config_info,
-        req_provision_info,
+    let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+        &shared_buffer,
+        &mut responder,
+        pcidoe_transport_encap,
+        &mut device_io_responder,
     );
 
-    let _ = requester.send_receive_spdm_algorithm().is_err();
+    let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
+
+    let _ = requester
+        .send_receive_spdm_algorithm(pcidoe_transport_encap2, &mut device_io_requester)
+        .is_err();
 }
 
 fn main() {

--- a/fuzz-target/requester/capability_req/src/main.rs
+++ b/fuzz-target/requester/capability_req/src/main.rs
@@ -17,25 +17,20 @@ fn fuzz_send_receive_spdm_capability(fuzzdata: &[u8]) {
 
     spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-    let mut responder = responder::ResponderContext::new(
-        &mut device_io_responder,
-        pcidoe_transport_encap,
-        rsp_config_info,
-        rsp_provision_info,
-    );
+    let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
     let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-    let mut device_io_requester =
-        fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-    let mut requester = requester::RequesterContext::new(
-        &mut device_io_requester,
-        pcidoe_transport_encap2,
-        req_config_info,
-        req_provision_info,
+    let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+        &shared_buffer,
+        &mut responder,
+        pcidoe_transport_encap,
+        &mut device_io_responder,
     );
 
-    let _ = requester.send_receive_spdm_capability();
+    let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
+
+    let _ =
+        requester.send_receive_spdm_capability(pcidoe_transport_encap2, &mut device_io_requester);
 }
 
 fn main() {

--- a/fuzz-target/requester/certificate_req/src/main.rs
+++ b/fuzz-target/requester/certificate_req/src/main.rs
@@ -25,12 +25,7 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         responder.common.reset_runtime_info();
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
@@ -45,15 +40,14 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
         }
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.base_asym_sel =
@@ -64,7 +58,14 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             requester.common.runtime_info.digest_context_m1m2 =
                 spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         }
-        let _ = requester.send_receive_spdm_certificate(None, 0).is_err();
+        let _ = requester
+            .send_receive_spdm_certificate(
+                None,
+                0,
+                pcidoe_transport_encap2,
+                &mut device_io_requester,
+            )
+            .is_err();
     }
     {
         // error 151 lines
@@ -75,12 +76,7 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info1,
-            rsp_provision_info1,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info1, rsp_provision_info1);
         responder.common.reset_runtime_info();
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         responder.common.negotiate_info.base_asym_sel =
@@ -93,15 +89,14 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
                 spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         }
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info1,
-            req_provision_info1,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info1, req_provision_info1);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.base_asym_sel =
@@ -112,7 +107,14 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             requester.common.runtime_info.digest_context_m1m2 =
                 spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         }
-        let _ = requester.send_receive_spdm_certificate(None, 0).is_err();
+        let _ = requester
+            .send_receive_spdm_certificate(
+                None,
+                0,
+                pcidoe_transport_encap2,
+                &mut device_io_requester,
+            )
+            .is_err();
     }
     {
         // error 155 lines
@@ -122,12 +124,7 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info2,
-            rsp_provision_info2,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info2, rsp_provision_info2);
         responder.common.reset_runtime_info();
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         responder.common.negotiate_info.base_asym_sel =
@@ -140,15 +137,14 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
                 spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         }
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info2,
-            req_provision_info2,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info2, req_provision_info2);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.base_asym_sel =
@@ -166,7 +162,14 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             requester.common.runtime_info.digest_context_m1m2 =
                 spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         }
-        let _ = requester.send_receive_spdm_certificate(None, 0).is_err();
+        let _ = requester
+            .send_receive_spdm_certificate(
+                None,
+                0,
+                pcidoe_transport_encap2,
+                &mut device_io_requester,
+            )
+            .is_err();
     }
     {
         // error 167 lines
@@ -176,12 +179,7 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info3,
-            rsp_provision_info3,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info3, rsp_provision_info3);
 
         responder.common.reset_runtime_info();
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
@@ -197,15 +195,14 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
         // digest_rsp
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info3,
-            req_provision_info3,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info3, req_provision_info3);
         let mut tmp = requester
             .common
             .provision_info
@@ -222,7 +219,14 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             requester.common.runtime_info.digest_context_m1m2 =
                 spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         }
-        let _ = requester.send_receive_spdm_certificate(None, 0).is_err();
+        let _ = requester
+            .send_receive_spdm_certificate(
+                None,
+                0,
+                pcidoe_transport_encap2,
+                &mut device_io_requester,
+            )
+            .is_err();
     }
     {
         let shared_buffer = SharedBuffer::new();
@@ -230,12 +234,7 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info4,
-            rsp_provision_info4,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info4, rsp_provision_info4);
 
         responder.common.reset_runtime_info();
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
@@ -249,15 +248,14 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
                 spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         }
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info4,
-            req_provision_info4,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info4, req_provision_info4);
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.base_asym_sel =
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
@@ -267,7 +265,14 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
             requester.common.runtime_info.digest_context_m1m2 =
                 spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         }
-        let _ = requester.send_receive_spdm_certificate(None, 0).is_err();
+        let _ = requester
+            .send_receive_spdm_certificate(
+                None,
+                0,
+                pcidoe_transport_encap2,
+                &mut device_io_requester,
+            )
+            .is_err();
     }
 }
 

--- a/fuzz-target/requester/end_session_req/src/main.rs
+++ b/fuzz-target/requester/end_session_req/src/main.rs
@@ -23,12 +23,7 @@ fn fuzz_send_receive_spdm_end_session(fuzzdata: &[u8]) {
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         spdmlib::crypto::aead::register(FUZZ_AEAD.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
 
@@ -42,15 +37,14 @@ fn fuzz_send_receive_spdm_end_session(fuzzdata: &[u8]) {
         );
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
 
@@ -64,7 +58,11 @@ fn fuzz_send_receive_spdm_end_session(fuzzdata: &[u8]) {
         );
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
-        let _ = requester.send_receive_spdm_end_session(4294901758);
+        let _ = requester.send_receive_spdm_end_session(
+            4294901758,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
+        );
     }
 
     {
@@ -75,12 +73,7 @@ fn fuzz_send_receive_spdm_end_session(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info1,
-            rsp_provision_info1,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info1, rsp_provision_info1);
 
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
 
@@ -94,15 +87,14 @@ fn fuzz_send_receive_spdm_end_session(fuzzdata: &[u8]) {
         );
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info1,
-            req_provision_info1,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info1, req_provision_info1);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
 
@@ -116,7 +108,11 @@ fn fuzz_send_receive_spdm_end_session(fuzzdata: &[u8]) {
         );
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
-        let _ = requester.send_receive_spdm_end_session(4294901758);
+        let _ = requester.send_receive_spdm_end_session(
+            4294901758,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
+        );
     }
 }
 

--- a/fuzz-target/requester/finish_req/src/main.rs
+++ b/fuzz-target/requester/finish_req/src/main.rs
@@ -24,12 +24,7 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         // capability_rsp
         responder.common.negotiate_info.req_ct_exponent_sel = 0;
@@ -73,15 +68,14 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
         responder.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
 
         requester.common.negotiate_info.req_ct_exponent_sel = 0;
         requester.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP
@@ -126,7 +120,12 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
 
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
-        let _ = requester.send_receive_spdm_finish(0, 4294901758);
+        let _ = requester.send_receive_spdm_finish(
+            0,
+            4294901758,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
+        );
     }
 
     {
@@ -137,12 +136,7 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info1,
-            rsp_provision_info1,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info1, rsp_provision_info1);
 
         responder.common.negotiate_info.req_ct_exponent_sel = 0;
         responder.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP
@@ -193,15 +187,14 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
         responder.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info1,
-            req_provision_info1,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info1, req_provision_info1);
 
         requester.common.negotiate_info.req_ct_exponent_sel = 0;
         requester.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP
@@ -244,7 +237,12 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
 
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
-        let _ = requester.send_receive_spdm_finish(0, 4294901758);
+        let _ = requester.send_receive_spdm_finish(
+            0,
+            4294901758,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
+        );
     }
 
     {
@@ -255,12 +253,7 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info2,
-            rsp_provision_info2,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info2, rsp_provision_info2);
 
         responder.common.negotiate_info.req_ct_exponent_sel = 0;
         responder.common.negotiate_info.req_capabilities_sel =
@@ -304,15 +297,14 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
         responder.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info2,
-            req_provision_info2,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info2, req_provision_info2);
 
         requester.common.negotiate_info.req_ct_exponent_sel = 0;
         requester.common.negotiate_info.req_capabilities_sel =
@@ -355,7 +347,12 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
 
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
-        let _ = requester.send_receive_spdm_finish(0, 4294901758);
+        let _ = requester.send_receive_spdm_finish(
+            0,
+            4294901758,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
+        );
     }
 }
 

--- a/fuzz-target/requester/heartbeat_req/src/main.rs
+++ b/fuzz-target/requester/heartbeat_req/src/main.rs
@@ -25,12 +25,7 @@ fn fuzz_send_receive_spdm_heartbeat(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
 
@@ -45,15 +40,14 @@ fn fuzz_send_receive_spdm_heartbeat(fuzzdata: &[u8]) {
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
 
@@ -67,7 +61,11 @@ fn fuzz_send_receive_spdm_heartbeat(fuzzdata: &[u8]) {
         );
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 
-        let _ = requester.send_receive_spdm_heartbeat(4294901758);
+        let _ = requester.send_receive_spdm_heartbeat(
+            4294901758,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
+        );
     }
 
     {
@@ -78,12 +76,7 @@ fn fuzz_send_receive_spdm_heartbeat(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info1,
-            rsp_provision_info1,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info1, rsp_provision_info1);
 
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
 
@@ -98,15 +91,14 @@ fn fuzz_send_receive_spdm_heartbeat(fuzzdata: &[u8]) {
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info1,
-            req_provision_info1,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info1, req_provision_info1);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
 
@@ -120,7 +112,11 @@ fn fuzz_send_receive_spdm_heartbeat(fuzzdata: &[u8]) {
         );
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 
-        let _ = requester.send_receive_spdm_heartbeat(4294901758);
+        let _ = requester.send_receive_spdm_heartbeat(
+            4294901758,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
+        );
     }
 }
 

--- a/fuzz-target/requester/key_exchange_req/src/main.rs
+++ b/fuzz-target/requester/key_exchange_req/src/main.rs
@@ -18,15 +18,10 @@ fn fuzz_send_receive_spdm_key_exchange(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let message_m = &[
+        let _message_m = &[
             0x11, 0xe0, 0x00, 0x00, 0x11, 0x60, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         responder.common.provision_info.my_cert_chain = Some(SpdmCertChainData {
             data_size: 512u16,
@@ -46,15 +41,14 @@ fn fuzz_send_receive_spdm_key_exchange(fuzzdata: &[u8]) {
         // responder.common.peer_info.peer_cert_chain.cert_chain = REQ_CERT_CHAIN_DATA;
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.aead_sel = SpdmAeadAlgo::AES_128_GCM;
@@ -71,6 +65,8 @@ fn fuzz_send_receive_spdm_key_exchange(fuzzdata: &[u8]) {
         let _ = requester.send_receive_spdm_key_exchange(
             0,
             SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeNone,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
     }
     {
@@ -81,15 +77,10 @@ fn fuzz_send_receive_spdm_key_exchange(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let message_m = &[
+        let _message_m = &[
             0x11, 0xe0, 0x00, 0x00, 0x11, 0x60, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info1,
-            rsp_provision_info1,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info1, rsp_provision_info1);
 
         responder.common.provision_info.my_cert_chain = Some(SpdmCertChainData {
             data_size: 512u16,
@@ -109,15 +100,14 @@ fn fuzz_send_receive_spdm_key_exchange(fuzzdata: &[u8]) {
         // responder.common.peer_info.peer_cert_chain.cert_chain = REQ_CERT_CHAIN_DATA;
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info1,
-            req_provision_info1,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info1, req_provision_info1);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.aead_sel = SpdmAeadAlgo::AES_128_GCM;
@@ -134,6 +124,8 @@ fn fuzz_send_receive_spdm_key_exchange(fuzzdata: &[u8]) {
         let _ = requester.send_receive_spdm_key_exchange(
             0,
             SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeNone,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
     }
 }

--- a/fuzz-target/requester/key_update_req/src/main.rs
+++ b/fuzz-target/requester/key_update_req/src/main.rs
@@ -26,12 +26,7 @@ fn fuzz_send_receive_spdm_key_update(fuzzdata: &[u8]) {
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         spdmlib::crypto::aead::register(FUZZ_AEAD.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         responder.common.session[0].setup(4294901758).unwrap();
         responder.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
@@ -43,15 +38,14 @@ fn fuzz_send_receive_spdm_key_update(fuzzdata: &[u8]) {
         );
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
         requester.common.session[0] = SpdmSession::new();
         requester.common.session[0].setup(4294901758).unwrap();
         requester.common.session[0].set_crypto_param(
@@ -62,8 +56,12 @@ fn fuzz_send_receive_spdm_key_update(fuzzdata: &[u8]) {
         );
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
-        let _ = requester
-            .send_receive_spdm_key_update(4294901758, SpdmKeyUpdateOperation::SpdmUpdateAllKeys);
+        let _ = requester.send_receive_spdm_key_update(
+            4294901758,
+            SpdmKeyUpdateOperation::SpdmUpdateAllKeys,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
+        );
     }
 
     {
@@ -74,12 +72,7 @@ fn fuzz_send_receive_spdm_key_update(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info1,
-            rsp_provision_info1,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info1, rsp_provision_info1);
 
         responder.common.session[0].setup(4294901758).unwrap();
         responder.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
@@ -91,15 +84,14 @@ fn fuzz_send_receive_spdm_key_update(fuzzdata: &[u8]) {
         );
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info1,
-            req_provision_info1,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info1, req_provision_info1);
 
         requester.common.session[0] = SpdmSession::new();
         requester.common.session[0].setup(4294901758).unwrap();
@@ -111,8 +103,12 @@ fn fuzz_send_receive_spdm_key_update(fuzzdata: &[u8]) {
         );
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
-        let _ = requester
-            .send_receive_spdm_key_update(4294901758, SpdmKeyUpdateOperation::SpdmUpdateAllKeys);
+        let _ = requester.send_receive_spdm_key_update(
+            4294901758,
+            SpdmKeyUpdateOperation::SpdmUpdateAllKeys,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
+        );
     }
     {
         let shared_buffer = SharedBuffer::new();
@@ -122,12 +118,7 @@ fn fuzz_send_receive_spdm_key_update(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info2,
-            rsp_provision_info2,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info2, rsp_provision_info2);
 
         responder.common.session[0].setup(4294901758).unwrap();
         responder.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
@@ -139,15 +130,14 @@ fn fuzz_send_receive_spdm_key_update(fuzzdata: &[u8]) {
         );
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info2,
-            req_provision_info2,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info2, req_provision_info2);
 
         requester.common.session[0] = SpdmSession::new();
         requester.common.session[0].setup(4294901758).unwrap();
@@ -159,8 +149,12 @@ fn fuzz_send_receive_spdm_key_update(fuzzdata: &[u8]) {
         );
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
-        let _ = requester
-            .send_receive_spdm_key_update(4294901758, SpdmKeyUpdateOperation::SpdmVerifyNewKey);
+        let _ = requester.send_receive_spdm_key_update(
+            4294901758,
+            SpdmKeyUpdateOperation::SpdmVerifyNewKey,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
+        );
     }
 }
 

--- a/fuzz-target/requester/measurement_req/src/main.rs
+++ b/fuzz-target/requester/measurement_req/src/main.rs
@@ -24,12 +24,7 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info3,
-            rsp_provision_info3,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info3, rsp_provision_info3);
 
         responder.common.negotiate_info.req_ct_exponent_sel = 0;
         responder.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP;
@@ -48,21 +43,20 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         responder.common.negotiate_info.measurement_hash_sel =
             SpdmMeasurementHashAlgo::TPM_ALG_SHA_384;
-        let message_m = &[0];
+        let _message_m = &[0];
         #[cfg(feature = "hashed-transcript-data")]
         responder.common.runtime_info.digest_context_m1m2.is_some();
         responder.common.reset_runtime_info();
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info3,
-            req_provision_info3,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info3, req_provision_info3);
 
         requester.common.negotiate_info.req_ct_exponent_sel = 0;
         requester.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP;
@@ -90,6 +84,8 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
             SpdmMeasurementOperation::SpdmMeasurementRequestAll,
             &mut total_number,
             &mut spdm_measurement_record_structure,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
     }
     {
@@ -100,12 +96,7 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         responder.common.negotiate_info.req_ct_exponent_sel = 0;
         responder.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP;
@@ -124,21 +115,20 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         responder.common.negotiate_info.measurement_hash_sel =
             SpdmMeasurementHashAlgo::TPM_ALG_SHA_384;
-        let message_m = &[0];
+        let _message_m = &[0];
         #[cfg(feature = "hashed-transcript-data")]
         responder.common.runtime_info.digest_context_m1m2.is_some();
         responder.common.reset_runtime_info();
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
 
         requester.common.negotiate_info.req_ct_exponent_sel = 0;
         requester.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP;
@@ -167,6 +157,8 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
             SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber,
             &mut total_number,
             &mut spdm_measurement_record_structure,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
     }
 
@@ -176,12 +168,7 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info1,
-            rsp_provision_info1,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info1, rsp_provision_info1);
 
         responder.common.negotiate_info.req_ct_exponent_sel = 0;
         responder.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP;
@@ -200,21 +187,20 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         responder.common.negotiate_info.measurement_hash_sel =
             SpdmMeasurementHashAlgo::TPM_ALG_SHA_384;
-        let message_m = &[0];
+        let _message_m = &[0];
         #[cfg(feature = "hashed-transcript-data")]
         responder.common.runtime_info.digest_context_m1m2.is_some();
         responder.common.reset_runtime_info();
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info1,
-            req_provision_info1,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info1, req_provision_info1);
 
         requester.common.negotiate_info.req_ct_exponent_sel = 0;
         requester.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP;
@@ -243,6 +229,8 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
             SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber,
             &mut total_number,
             &mut spdm_measurement_record_structure,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
     }
     {
@@ -251,12 +239,7 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
 
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info2,
-            rsp_provision_info2,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info2, rsp_provision_info2);
 
         responder.common.negotiate_info.req_ct_exponent_sel = 0;
         responder.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP;
@@ -275,21 +258,20 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         responder.common.negotiate_info.measurement_hash_sel =
             SpdmMeasurementHashAlgo::TPM_ALG_SHA_384;
-        let message_m = &[0];
+        let _message_m = &[0];
         #[cfg(feature = "hashed-transcript-data")]
         responder.common.runtime_info.digest_context_m1m2.is_some();
         responder.common.reset_runtime_info();
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info2,
-            req_provision_info2,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info2, req_provision_info2);
 
         requester.common.negotiate_info.req_ct_exponent_sel = 0;
         requester.common.negotiate_info.req_capabilities_sel = SpdmRequestCapabilityFlags::CERT_CAP;
@@ -318,6 +300,8 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
             SpdmMeasurementOperation::Unknown(4),
             &mut total_number,
             &mut spdm_measurement_record_structure,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
     }
 }

--- a/fuzz-target/requester/psk_exchange_req/src/main.rs
+++ b/fuzz-target/requester/psk_exchange_req/src/main.rs
@@ -18,27 +18,21 @@ fn fuzz_send_receive_spdm_psk_exchange(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         responder.common.negotiate_info.aead_sel = SpdmAeadAlgo::AES_256_GCM;
         responder.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.aead_sel = SpdmAeadAlgo::AES_256_GCM;
@@ -47,6 +41,8 @@ fn fuzz_send_receive_spdm_psk_exchange(fuzzdata: &[u8]) {
 
         let _ = requester.send_receive_spdm_psk_exchange(
             SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeNone,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
     }
     {
@@ -57,27 +53,21 @@ fn fuzz_send_receive_spdm_psk_exchange(fuzzdata: &[u8]) {
 
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info1,
-            rsp_provision_info1,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info1, rsp_provision_info1);
 
         responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         responder.common.negotiate_info.aead_sel = SpdmAeadAlgo::AES_256_GCM;
         responder.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester =
-            fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = requester::RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info1,
-            req_provision_info1,
+        let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = requester::RequesterContext::new(req_config_info1, req_provision_info1);
 
         requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.negotiate_info.aead_sel = SpdmAeadAlgo::AES_256_GCM;
@@ -86,6 +76,8 @@ fn fuzz_send_receive_spdm_psk_exchange(fuzzdata: &[u8]) {
 
         let _ = requester.send_receive_spdm_psk_exchange(
             SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeNone,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
     }
 }

--- a/fuzz-target/requester/psk_finish_req/src/main.rs
+++ b/fuzz-target/requester/psk_finish_req/src/main.rs
@@ -19,12 +19,7 @@ fn fuzz_send_receive_spdm_psk_finish(fuzzdata: &[u8]) {
 
     spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-    let mut responder = responder::ResponderContext::new(
-        &mut device_io_responder,
-        pcidoe_transport_encap,
-        rsp_config_info,
-        rsp_provision_info,
-    );
+    let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
     responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
     responder.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
@@ -53,15 +48,14 @@ fn fuzz_send_receive_spdm_psk_finish(fuzzdata: &[u8]) {
     }
 
     let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-    let mut device_io_requester =
-        fake_device_io::FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-    let mut requester = requester::RequesterContext::new(
-        &mut device_io_requester,
-        pcidoe_transport_encap2,
-        req_config_info,
-        req_provision_info,
+    let mut device_io_requester = fake_device_io::FakeSpdmDeviceIo::new(
+        &shared_buffer,
+        &mut responder,
+        pcidoe_transport_encap,
+        &mut device_io_responder,
     );
+
+    let mut requester = requester::RequesterContext::new(req_config_info, req_provision_info);
 
     requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
     requester.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
@@ -90,7 +84,11 @@ fn fuzz_send_receive_spdm_psk_finish(fuzzdata: &[u8]) {
             spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
     }
 
-    let _ = requester.send_receive_spdm_psk_finish(4294901758);
+    let _ = requester.send_receive_spdm_psk_finish(
+        4294901758,
+        pcidoe_transport_encap2,
+        &mut device_io_requester,
+    );
 }
 
 fn main() {

--- a/fuzz-target/requester/version_req/src/main.rs
+++ b/fuzz-target/requester/version_req/src/main.rs
@@ -25,24 +25,21 @@ fn fuzz_send_receive_spdm_version(fuzzdata: &[u8]) {
         spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         spdmlib::time::register(SPDM_TIME_IMPL.clone());
 
-        let mut responder = ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester = FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
 
-        let _ = requester.send_receive_spdm_version().is_err();
+        let mut requester = RequesterContext::new(req_config_info, req_provision_info);
+
+        let _ = requester
+            .send_receive_spdm_version(pcidoe_transport_encap2, &mut device_io_requester)
+            .is_err();
     }
 }
 

--- a/fuzz-target/responder/algorithm_rsp/src/main.rs
+++ b/fuzz-target/responder/algorithm_rsp/src/main.rs
@@ -15,19 +15,15 @@ fn fuzz_handle_spdm_algorithm(data: &[u8]) {
 
     let shared_buffer = SharedBuffer::new();
     let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
 
-    let mut context = responder::ResponderContext::new(
-        &mut socket_io_transport,
-        if USE_PCIDOE {
-            pcidoe_transport_encap
-        } else {
-            mctp_transport_encap
-        },
-        config_info,
-        provision_info,
-    );
+    let mut context = responder::ResponderContext::new(config_info, provision_info);
 
-    context.handle_spdm_algorithm(data);
+    context.handle_spdm_algorithm(data, transport_encap, &mut socket_io_transport);
 }
 
 fn main() {

--- a/fuzz-target/responder/capability_rsp/src/main.rs
+++ b/fuzz-target/responder/capability_rsp/src/main.rs
@@ -13,19 +13,15 @@ fn fuzz_handle_spdm_capability(data: &[u8]) {
 
     let shared_buffer = SharedBuffer::new();
     let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
 
-    let mut context = responder::ResponderContext::new(
-        &mut socket_io_transport,
-        if USE_PCIDOE {
-            pcidoe_transport_encap
-        } else {
-            mctp_transport_encap
-        },
-        config_info,
-        provision_info,
-    );
+    let mut context = responder::ResponderContext::new(config_info, provision_info);
 
-    context.handle_spdm_capability(data);
+    context.handle_spdm_capability(data, transport_encap, &mut socket_io_transport);
 }
 
 fn main() {

--- a/fuzz-target/responder/certificate_rsp/src/main.rs
+++ b/fuzz-target/responder/certificate_rsp/src/main.rs
@@ -14,17 +14,13 @@ fn fuzz_handle_spdm_certificate(data: &[u8]) {
 
     let shared_buffer = SharedBuffer::new();
     let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
 
-    let mut context = responder::ResponderContext::new(
-        &mut socket_io_transport,
-        if USE_PCIDOE {
-            pcidoe_transport_encap
-        } else {
-            mctp_transport_encap
-        },
-        config_info,
-        provision_info,
-    );
+    let mut context = responder::ResponderContext::new(config_info, provision_info);
 
     context.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
 
@@ -34,7 +30,7 @@ fn fuzz_handle_spdm_certificate(data: &[u8]) {
             spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
     }
 
-    context.handle_spdm_certificate(data, None);
+    context.handle_spdm_certificate(data, None, transport_encap, &mut socket_io_transport);
 }
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]

--- a/fuzz-target/responder/challenge_rsp/src/main.rs
+++ b/fuzz-target/responder/challenge_rsp/src/main.rs
@@ -15,17 +15,13 @@ fn fuzz_handle_spdm_challenge(data: &[u8]) {
 
     let shared_buffer = SharedBuffer::new();
     let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
 
-    let mut context = responder::ResponderContext::new(
-        &mut socket_io_transport,
-        if USE_PCIDOE {
-            pcidoe_transport_encap
-        } else {
-            mctp_transport_encap
-        },
-        config_info,
-        provision_info,
-    );
+    let mut context = responder::ResponderContext::new(config_info, provision_info);
     context.common.provision_info.my_cert_chain = Some(REQ_CERT_CHAIN_DATA);
     context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
     context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
@@ -34,7 +30,7 @@ fn fuzz_handle_spdm_challenge(data: &[u8]) {
         context.common.runtime_info.digest_context_m1m2 =
             spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
     }
-    context.handle_spdm_challenge(data);
+    context.handle_spdm_challenge(data, transport_encap, &mut socket_io_transport);
 }
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]

--- a/fuzz-target/responder/end_session_rsp/src/main.rs
+++ b/fuzz-target/responder/end_session_rsp/src/main.rs
@@ -18,17 +18,13 @@ fn fuzz_handle_spdm_end_session(data: &[u8]) {
 
     let shared_buffer = SharedBuffer::new();
     let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
 
-    let mut context = responder::ResponderContext::new(
-        &mut socket_io_transport,
-        if USE_PCIDOE {
-            pcidoe_transport_encap
-        } else {
-            mctp_transport_encap
-        },
-        config_info,
-        provision_info,
-    );
+    let mut context = responder::ResponderContext::new(config_info, provision_info);
 
     context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
     // context.common.session = [SpdmSession::new(); 4];
@@ -43,7 +39,12 @@ fn fuzz_handle_spdm_end_session(data: &[u8]) {
 
     context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 
-    let _ = context.handle_spdm_end_session(4294901758, data);
+    let _ = context.handle_spdm_end_session(
+        4294901758,
+        data,
+        transport_encap,
+        &mut socket_io_transport,
+    );
 }
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]

--- a/fuzz-target/responder/finish_rsp/src/main.rs
+++ b/fuzz-target/responder/finish_rsp/src/main.rs
@@ -23,19 +23,15 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
 
     let shared_buffer = SharedBuffer::new();
     let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
 
     {
         // all pass
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            if USE_PCIDOE {
-                pcidoe_transport_encap
-            } else {
-                mctp_transport_encap
-            },
-            config_info,
-            provision_info,
-        );
+        let mut context = responder::ResponderContext::new(config_info, provision_info);
 
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
@@ -65,23 +61,14 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
 
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 
-        context.handle_spdm_finish(4294901758, data);
+        context.handle_spdm_finish(4294901758, data, transport_encap, &mut socket_io_transport);
         let mut req_buf = [0u8; 1024];
         socket_io_transport.receive(&mut req_buf, 60).unwrap();
     }
 
     {
         // runtime info message_a add, err 39 lines
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            if USE_PCIDOE {
-                pcidoe_transport_encap
-            } else {
-                mctp_transport_encap
-            },
-            config_info2,
-            provision_info2,
-        );
+        let mut context = responder::ResponderContext::new(config_info2, provision_info2);
 
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
@@ -109,21 +96,12 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
 
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
-        context.handle_spdm_finish(4294901758, data);
+        context.handle_spdm_finish(4294901758, data, transport_encap, &mut socket_io_transport);
     }
 
     {
         // 53 lines
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            if USE_PCIDOE {
-                pcidoe_transport_encap
-            } else {
-                mctp_transport_encap
-            },
-            config_info1,
-            provision_info1,
-        );
+        let mut context = responder::ResponderContext::new(config_info1, provision_info1);
 
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_256;
@@ -151,20 +129,11 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
                 spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
         }
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
-        context.handle_spdm_finish(4294901758, data);
+        context.handle_spdm_finish(4294901758, data, transport_encap, &mut socket_io_transport);
     }
     {
         // error 98 lines
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            if USE_PCIDOE {
-                pcidoe_transport_encap
-            } else {
-                mctp_transport_encap
-            },
-            config_info3,
-            provision_info3,
-        );
+        let mut context = responder::ResponderContext::new(config_info3, provision_info3);
 
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
@@ -198,20 +167,11 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
 
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionHandshaking);
 
-        context.handle_spdm_finish(4294901758, data);
+        context.handle_spdm_finish(4294901758, data, transport_encap, &mut socket_io_transport);
     }
     {
         // error 109 lines
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            if USE_PCIDOE {
-                pcidoe_transport_encap
-            } else {
-                mctp_transport_encap
-            },
-            config_info4,
-            provision_info4,
-        );
+        let mut context = responder::ResponderContext::new(config_info4, provision_info4);
 
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
@@ -251,21 +211,12 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
             .message_a
             .append_message(&[1u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE - 103]);
 
-        context.handle_spdm_finish(4294901758, data);
+        context.handle_spdm_finish(4294901758, data, transport_encap, &mut socket_io_transport);
     }
 
     {
         // all pass
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            if USE_PCIDOE {
-                pcidoe_transport_encap
-            } else {
-                mctp_transport_encap
-            },
-            config_info5,
-            provision_info5,
-        );
+        let mut context = responder::ResponderContext::new(config_info5, provision_info5);
 
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
@@ -300,7 +251,7 @@ fn fuzz_handle_spdm_finish(data: &[u8]) {
 
         context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 
-        context.handle_spdm_finish(4294901758, data);
+        context.handle_spdm_finish(4294901758, data, transport_encap, &mut socket_io_transport);
         let mut req_buf = [0u8; 1024];
         socket_io_transport.receive(&mut req_buf, 60).unwrap();
     }

--- a/fuzz-target/responder/heartbeat_rsp/src/main.rs
+++ b/fuzz-target/responder/heartbeat_rsp/src/main.rs
@@ -17,17 +17,13 @@ fn fuzz_handle_spdm_heartbeat(data: &[u8]) {
 
     let shared_buffer = SharedBuffer::new();
     let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
 
-    let mut context = responder::ResponderContext::new(
-        &mut socket_io_transport,
-        if USE_PCIDOE {
-            pcidoe_transport_encap
-        } else {
-            mctp_transport_encap
-        },
-        config_info,
-        provision_info,
-    );
+    let mut context = responder::ResponderContext::new(config_info, provision_info);
 
     context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
     // context.common.session = [SpdmSession::new(); 4];
@@ -41,7 +37,7 @@ fn fuzz_handle_spdm_heartbeat(data: &[u8]) {
     );
     context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 
-    context.handle_spdm_heartbeat(4294901758, data);
+    context.handle_spdm_heartbeat(4294901758, data, transport_encap, &mut socket_io_transport);
 }
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]

--- a/fuzz-target/responder/key_update_rsp/src/main.rs
+++ b/fuzz-target/responder/key_update_rsp/src/main.rs
@@ -17,17 +17,13 @@ fn fuzz_handle_spdm_key_update(data: &[u8]) {
 
     let shared_buffer = SharedBuffer::new();
     let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
 
-    let mut context = responder::ResponderContext::new(
-        &mut socket_io_transport,
-        if USE_PCIDOE {
-            pcidoe_transport_encap
-        } else {
-            mctp_transport_encap
-        },
-        config_info,
-        provision_info,
-    );
+    let mut context = responder::ResponderContext::new(config_info, provision_info);
 
     context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
     // context.common.session = [SpdmSession::new(); 4];
@@ -41,7 +37,7 @@ fn fuzz_handle_spdm_key_update(data: &[u8]) {
     );
     context.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
 
-    context.handle_spdm_key_update(4294901758, data);
+    context.handle_spdm_key_update(4294901758, data, transport_encap, &mut socket_io_transport);
 }
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]

--- a/fuzz-target/responder/keyexchange_rsp/src/main.rs
+++ b/fuzz-target/responder/keyexchange_rsp/src/main.rs
@@ -12,22 +12,18 @@ fn fuzz_handle_spdm_key_exchange(data: &[u8]) {
     let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
     let mctp_transport_encap = &mut MctpTransportEncap {};
 
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
+
     spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
     {
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            if USE_PCIDOE {
-                pcidoe_transport_encap
-            } else {
-                mctp_transport_encap
-            },
-            config_info,
-            provision_info,
-        );
+        let mut context = responder::ResponderContext::new(config_info, provision_info);
         // algorithm_rsp
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
@@ -38,23 +34,14 @@ fn fuzz_handle_spdm_key_exchange(data: &[u8]) {
 
         context.common.reset_runtime_info();
 
-        let _ = context.handle_spdm_key_exchange(data);
+        let _ = context.handle_spdm_key_exchange(data, transport_encap, &mut socket_io_transport);
     }
 
     {
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
 
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            if USE_PCIDOE {
-                pcidoe_transport_encap
-            } else {
-                mctp_transport_encap
-            },
-            config_info1,
-            provision_info1,
-        );
+        let mut context = responder::ResponderContext::new(config_info1, provision_info1);
 
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
@@ -72,23 +59,14 @@ fn fuzz_handle_spdm_key_exchange(data: &[u8]) {
         context.common.session[2].setup(4294901758).unwrap();
         context.common.session[3].setup(4294901758).unwrap();
 
-        let _ = context.handle_spdm_key_exchange(data);
+        let _ = context.handle_spdm_key_exchange(data, transport_encap, &mut socket_io_transport);
     }
 
     {
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
 
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            if USE_PCIDOE {
-                pcidoe_transport_encap
-            } else {
-                mctp_transport_encap
-            },
-            config_info2,
-            provision_info2,
-        );
+        let mut context = responder::ResponderContext::new(config_info2, provision_info2);
 
         context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
@@ -100,7 +78,7 @@ fn fuzz_handle_spdm_key_exchange(data: &[u8]) {
         context.common.provision_info.my_cert_chain_data = None;
         context.common.reset_runtime_info();
 
-        let _ = context.handle_spdm_key_exchange(data);
+        let _ = context.handle_spdm_key_exchange(data, transport_encap, &mut socket_io_transport);
     }
 }
 fn main() {

--- a/fuzz-target/responder/measurement_rsp/src/main.rs
+++ b/fuzz-target/responder/measurement_rsp/src/main.rs
@@ -14,17 +14,13 @@ fn fuzz_handle_spdm_measurement(data: &[u8]) {
 
     let shared_buffer = SharedBuffer::new();
     let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
 
-    let mut context = responder::ResponderContext::new(
-        &mut socket_io_transport,
-        if USE_PCIDOE {
-            pcidoe_transport_encap
-        } else {
-            mctp_transport_encap
-        },
-        config_info,
-        provision_info,
-    );
+    let mut context = responder::ResponderContext::new(config_info, provision_info);
 
     context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
     context.common.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
@@ -38,7 +34,7 @@ fn fuzz_handle_spdm_measurement(data: &[u8]) {
             spdmlib::crypto::hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
     }
 
-    context.handle_spdm_measurement(None, data);
+    context.handle_spdm_measurement(None, data, transport_encap, &mut socket_io_transport);
 }
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]

--- a/fuzz-target/responder/version_rsp/src/main.rs
+++ b/fuzz-target/responder/version_rsp/src/main.rs
@@ -13,19 +13,15 @@ fn fuzz_handle_spdm_version(data: &[u8]) {
 
     let shared_buffer = SharedBuffer::new();
     let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
+    let transport_encap: &mut dyn SpdmTransportEncap = if USE_PCIDOE {
+        pcidoe_transport_encap
+    } else {
+        mctp_transport_encap
+    };
 
-    let mut context = responder::ResponderContext::new(
-        &mut socket_io_transport,
-        if USE_PCIDOE {
-            pcidoe_transport_encap
-        } else {
-            mctp_transport_encap
-        },
-        config_info,
-        provision_info,
-    );
+    let mut context = responder::ResponderContext::new(config_info, provision_info);
 
-    context.handle_spdm_version(data);
+    context.handle_spdm_version(data, transport_encap, &mut socket_io_transport);
     let mut req_buf = [0u8; 1024];
     socket_io_transport.receive(&mut req_buf, 60).unwrap();
     println!("Received: {:?}", req_buf);

--- a/spdmlib/src/message/algorithm.rs
+++ b/spdmlib/src/message/algorithm.rs
@@ -271,7 +271,7 @@ mod tests {
         let device_io = &mut DeviceIO {};
         let config_info = SpdmConfigInfo::default();
         let provision_info = SpdmProvisionInfo::default();
-        let mut context = SpdmContext::new(device_io, transport_encap, config_info, provision_info);
+        let mut context = SpdmContext::new(config_info, provision_info);
 
         value.spdm_encode(&mut context, &mut writer);
         let mut reader = Reader::init(u8_slice);
@@ -326,7 +326,7 @@ mod tests {
         let device_io = &mut DeviceIO {};
         let config_info = SpdmConfigInfo::default();
         let provision_info = SpdmProvisionInfo::default();
-        let mut context = SpdmContext::new(device_io, transport_encap, config_info, provision_info);
+        let mut context = SpdmContext::new(config_info, provision_info);
 
         value.spdm_encode(&mut context, &mut writer);
         let mut reader = Reader::init(u8_slice);
@@ -362,7 +362,7 @@ mod tests {
         let device_io = &mut DeviceIO {};
         let config_info = SpdmConfigInfo::default();
         let provision_info = SpdmProvisionInfo::default();
-        let mut context = SpdmContext::new(device_io, transport_encap, config_info, provision_info);
+        let mut context = SpdmContext::new(config_info, provision_info);
 
         value.spdm_encode(&mut context, &mut writer);
         u8_slice[26] = 1;
@@ -400,7 +400,7 @@ mod tests {
         let device_io = &mut DeviceIO {};
         let config_info = SpdmConfigInfo::default();
         let provision_info = SpdmProvisionInfo::default();
-        let mut context = SpdmContext::new(device_io, transport_encap, config_info, provision_info);
+        let mut context = SpdmContext::new(config_info, provision_info);
 
         context.config_info.measurement_specification = SpdmMeasurementSpecification::DMTF;
         context.config_info.measurement_hash_algo = SpdmMeasurementHashAlgo::RAW_BIT_STREAM;
@@ -494,7 +494,7 @@ mod tests {
         let device_io = &mut DeviceIO {};
         let config_info = SpdmConfigInfo::default();
         let provision_info = SpdmProvisionInfo::default();
-        let mut context = SpdmContext::new(device_io, transport_encap, config_info, provision_info);
+        let mut context = SpdmContext::new(config_info, provision_info);
 
         value.spdm_encode(&mut context, &mut writer);
         let mut reader = Reader::init(u8_slice);

--- a/spdmlib/src/message/mod_test.common.inc.rs
+++ b/spdmlib/src/message/mod_test.common.inc.rs
@@ -10,8 +10,7 @@ macro_rules! create_spdm_context {
         let config_info = SpdmConfigInfo::default();
         let provision_info = SpdmProvisionInfo::default();
         #[allow(unused, unused_mut)]
-        let mut $context_name =
-            SpdmContext::new(device_io, transport_encap, config_info, provision_info);
+        let mut $context_name = SpdmContext::new(config_info, provision_info);
     };
 }
 

--- a/spdmlib/src/requester/context.rs
+++ b/spdmlib/src/requester/context.rs
@@ -8,31 +8,28 @@ use crate::config;
 use crate::error::{spdm_err, spdm_result_err, SpdmResult};
 use crate::protocol::*;
 
-pub struct RequesterContext<'a> {
-    pub common: common::SpdmContext<'a>,
+pub struct RequesterContext {
+    pub common: common::SpdmContext,
 }
 
-impl<'a> RequesterContext<'a> {
+impl RequesterContext {
     pub fn new(
-        device_io: &'a mut dyn SpdmDeviceIo,
-        transport_encap: &'a mut dyn SpdmTransportEncap,
         config_info: common::SpdmConfigInfo,
         provision_info: common::SpdmProvisionInfo,
     ) -> Self {
         RequesterContext {
-            common: common::SpdmContext::new(
-                device_io,
-                transport_encap,
-                config_info,
-                provision_info,
-            ),
+            common: common::SpdmContext::new(config_info, provision_info),
         }
     }
 
-    pub fn init_connection(&mut self) -> SpdmResult {
-        self.send_receive_spdm_version()?;
-        self.send_receive_spdm_capability()?;
-        self.send_receive_spdm_algorithm()
+    pub fn init_connection(
+        &mut self,
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) -> SpdmResult {
+        self.send_receive_spdm_version(transport_encap, device_io)?;
+        self.send_receive_spdm_capability(transport_encap, device_io)?;
+        self.send_receive_spdm_algorithm(transport_encap, device_io)
     }
 
     pub fn start_session(
@@ -40,12 +37,19 @@ impl<'a> RequesterContext<'a> {
         use_psk: bool,
         slot_id: u8,
         measurement_summary_hash_type: SpdmMeasurementSummaryHashType,
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
     ) -> SpdmResult<u32> {
         if !use_psk {
-            let result =
-                self.send_receive_spdm_key_exchange(slot_id, measurement_summary_hash_type);
+            let result = self.send_receive_spdm_key_exchange(
+                slot_id,
+                measurement_summary_hash_type,
+                transport_encap,
+                device_io,
+            );
             if let Ok(session_id) = result {
-                let result = self.send_receive_spdm_finish(slot_id, session_id);
+                let result =
+                    self.send_receive_spdm_finish(slot_id, session_id, transport_encap, device_io);
                 if result.is_ok() {
                     Ok(session_id)
                 } else {
@@ -55,9 +59,14 @@ impl<'a> RequesterContext<'a> {
                 spdm_result_err!(EIO)
             }
         } else {
-            let result = self.send_receive_spdm_psk_exchange(measurement_summary_hash_type);
+            let result = self.send_receive_spdm_psk_exchange(
+                measurement_summary_hash_type,
+                transport_encap,
+                device_io,
+            );
             if let Ok(session_id) = result {
-                let result = self.send_receive_spdm_psk_finish(session_id);
+                let result =
+                    self.send_receive_spdm_psk_finish(session_id, transport_encap, device_io);
                 if result.is_ok() {
                     Ok(session_id)
                 } else {
@@ -69,14 +78,27 @@ impl<'a> RequesterContext<'a> {
         }
     }
 
-    pub fn end_session(&mut self, session_id: u32) -> SpdmResult {
-        self.send_receive_spdm_end_session(session_id)
+    pub fn end_session(
+        &mut self,
+        session_id: u32,
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) -> SpdmResult {
+        self.send_receive_spdm_end_session(session_id, transport_encap, device_io)
     }
 
-    pub fn send_message(&mut self, send_buffer: &[u8]) -> SpdmResult {
+    pub fn send_message(
+        &mut self,
+        send_buffer: &[u8],
+        // transport_buffer: &mut [u8],
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) -> SpdmResult {
         let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
-        let used = self.common.encap(send_buffer, &mut transport_buffer)?;
-        self.common.device_io.send(&transport_buffer[..used])
+        let used = self
+            .common
+            .encap(send_buffer, &mut transport_buffer, transport_encap)?;
+        device_io.send(&transport_buffer[..used])
     }
 
     pub fn send_secured_message(
@@ -84,6 +106,8 @@ impl<'a> RequesterContext<'a> {
         session_id: u32,
         send_buffer: &[u8],
         is_app_message: bool,
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
     ) -> SpdmResult {
         let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
         let used = self.common.encode_secured_message(
@@ -92,14 +116,17 @@ impl<'a> RequesterContext<'a> {
             &mut transport_buffer,
             true,
             is_app_message,
+            transport_encap,
         )?;
-        self.common.device_io.send(&transport_buffer[..used])
+        device_io.send(&transport_buffer[..used])
     }
 
     pub fn receive_message(
         &mut self,
         receive_buffer: &mut [u8],
         crypto_request: bool,
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
     ) -> SpdmResult<usize> {
         info!("receive_message!\n");
 
@@ -110,13 +137,12 @@ impl<'a> RequesterContext<'a> {
         };
 
         let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
-        let used = self
-            .common
-            .device_io
+        let used = device_io
             .receive(&mut transport_buffer, timeout)
             .map_err(|_| spdm_err!(EIO))?;
 
-        self.common.decap(&transport_buffer[..used], receive_buffer)
+        self.common
+            .decap(&transport_buffer[..used], receive_buffer, transport_encap)
     }
 
     pub fn receive_secured_message(
@@ -124,6 +150,8 @@ impl<'a> RequesterContext<'a> {
         session_id: u32,
         receive_buffer: &mut [u8],
         crypto_request: bool,
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
     ) -> SpdmResult<usize> {
         info!("receive_secured_message!\n");
 
@@ -135,14 +163,16 @@ impl<'a> RequesterContext<'a> {
 
         let mut transport_buffer = [0u8; config::DATA_TRANSFER_SIZE];
 
-        let used = self
-            .common
-            .device_io
+        let used = device_io
             .receive(&mut transport_buffer, timeout)
             .map_err(|_| spdm_err!(EIO))?;
 
-        self.common
-            .decode_secured_message(session_id, &transport_buffer[..used], receive_buffer)
+        self.common.decode_secured_message(
+            session_id,
+            &transport_buffer[..used],
+            receive_buffer,
+            transport_encap,
+        )
     }
 }
 
@@ -167,36 +197,44 @@ mod tests_requester {
 
         crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester = FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
 
-        let status = requester.init_connection().is_ok();
+        let mut requester = RequesterContext::new(req_config_info, req_provision_info);
+
+        let status = requester
+            .init_connection(pcidoe_transport_encap2, &mut device_io_requester)
+            .is_ok();
         assert!(status);
 
-        let status = requester.send_receive_spdm_digest(None).is_ok();
+        let status = requester
+            .send_receive_spdm_digest(None, pcidoe_transport_encap2, &mut device_io_requester)
+            .is_ok();
         assert!(status);
 
-        let status = requester.send_receive_spdm_certificate(None, 0).is_ok();
+        let status = requester
+            .send_receive_spdm_certificate(
+                None,
+                0,
+                pcidoe_transport_encap2,
+                &mut device_io_requester,
+            )
+            .is_ok();
         assert!(status);
 
         let result = requester.start_session(
             false,
             0,
             SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeAll,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
         assert!(result.is_ok());
 
@@ -204,6 +242,8 @@ mod tests_requester {
             false,
             0,
             SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeAll,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
         assert!(result.is_ok());
 
@@ -211,6 +251,8 @@ mod tests_requester {
             true,
             0,
             SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeAll,
+            pcidoe_transport_encap2,
+            &mut device_io_requester,
         );
         assert!(result.is_ok());
     }
@@ -226,12 +268,7 @@ mod tests_requester {
 
         crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         responder.common.negotiate_info.base_hash_sel =
             crate::protocol::SpdmBaseHashAlgo::TPM_ALG_SHA_384;
@@ -249,14 +286,14 @@ mod tests_requester {
             .set_session_state(crate::common::session::SpdmSessionState::SpdmSessionEstablished);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester = FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = RequesterContext::new(req_config_info, req_provision_info);
 
         requester.common.negotiate_info.base_hash_sel =
             crate::protocol::SpdmBaseHashAlgo::TPM_ALG_SHA_384;
@@ -288,14 +325,26 @@ mod tests_requester {
         let used = writer.used();
 
         let status = requester
-            .send_secured_message(session_id, &send_buffer[..used], false)
+            .send_secured_message(
+                session_id,
+                &send_buffer[..used],
+                false,
+                pcidoe_transport_encap2,
+                &mut device_io_requester,
+            )
             .is_ok();
         assert!(status);
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
 
         let status = requester
-            .receive_secured_message(session_id, &mut receive_buffer, false)
+            .receive_secured_message(
+                session_id,
+                &mut receive_buffer,
+                false,
+                pcidoe_transport_encap2,
+                &mut device_io_requester,
+            )
             .is_ok();
         assert!(status);
     }

--- a/spdmlib/src/requester/finish_req.rs
+++ b/spdmlib/src/requester/finish_req.rs
@@ -13,22 +13,42 @@ use alloc::boxed::Box;
 
 use crate::common::ManagedBuffer;
 
-impl<'a> RequesterContext<'a> {
-    pub fn send_receive_spdm_finish(&mut self, slot_id: u8, session_id: u32) -> SpdmResult {
+impl RequesterContext {
+    pub fn send_receive_spdm_finish(
+        &mut self,
+        slot_id: u8,
+        session_id: u32,
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) -> SpdmResult {
         info!("send spdm finish\n");
         let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
         let (send_used, base_hash_size, message_f) =
             self.encode_spdm_finish(session_id, slot_id, &mut send_buffer)?;
-        self.send_secured_message(session_id, &send_buffer[..send_used], false)?;
+        self.send_secured_message(
+            session_id,
+            &send_buffer[..send_used],
+            false,
+            transport_encap,
+            device_io,
+        )?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
-        let receive_used = self.receive_secured_message(session_id, &mut receive_buffer, false)?;
+        let receive_used = self.receive_secured_message(
+            session_id,
+            &mut receive_buffer,
+            false,
+            transport_encap,
+            device_io,
+        )?;
         self.handle_spdm_finish_response(
             session_id,
             slot_id,
             base_hash_size,
             message_f,
             &receive_buffer[..receive_used],
+            transport_encap,
+            device_io,
         )
     }
 
@@ -129,6 +149,7 @@ impl<'a> RequesterContext<'a> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn handle_spdm_finish_response(
         &mut self,
         session_id: u32,
@@ -137,6 +158,8 @@ impl<'a> RequesterContext<'a> {
         #[cfg(not(feature = "hashed-transcript-data"))] mut message_f: ManagedBuffer,
         #[cfg(feature = "hashed-transcript-data")] message_f: ManagedBuffer, // never use message_f for hashed-transcript-data, use session.runtime_info.message_f
         receive_buffer: &[u8],
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
     ) -> SpdmResult {
         let in_clear_text = self
             .common
@@ -323,6 +346,8 @@ impl<'a> RequesterContext<'a> {
                         receive_buffer,
                         SpdmRequestResponseCode::SpdmRequestFinish,
                         SpdmRequestResponseCode::SpdmResponseFinishRsp,
+                        transport_encap,
+                        device_io,
                     );
                     match erm {
                         Ok(rm) => {
@@ -334,6 +359,8 @@ impl<'a> RequesterContext<'a> {
                                 base_hash_size,
                                 message_f,
                                 &receive_buffer[..used],
+                                transport_encap,
+                                device_io,
                             )
                         }
                         _ => spdm_result_err!(EINVAL),
@@ -365,12 +392,7 @@ mod tests_requester {
 
         crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         responder.common.negotiate_info.req_ct_exponent_sel = 0;
         responder.common.negotiate_info.req_capabilities_sel =
@@ -424,14 +446,14 @@ mod tests_requester {
         );
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester = FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = RequesterContext::new(req_config_info, req_provision_info);
 
         requester.common.negotiate_info.req_ct_exponent_sel = 0;
         requester.common.negotiate_info.req_capabilities_sel =
@@ -487,7 +509,14 @@ mod tests_requester {
             },
         );
         // let _ = requester.send_receive_spdm_finish(4294901758);
-        let status = requester.send_receive_spdm_finish(0, 4294901758).is_ok();
+        let status = requester
+            .send_receive_spdm_finish(
+                0,
+                4294901758,
+                pcidoe_transport_encap2,
+                &mut device_io_requester,
+            )
+            .is_ok();
         assert!(status);
     }
 }

--- a/spdmlib/src/requester/get_capabilities_req.rs
+++ b/spdmlib/src/requester/get_capabilities_req.rs
@@ -7,15 +7,25 @@ use crate::message::*;
 use crate::protocol::*;
 use crate::requester::*;
 
-impl<'a> RequesterContext<'a> {
-    pub fn send_receive_spdm_capability(&mut self) -> SpdmResult {
+impl RequesterContext {
+    pub fn send_receive_spdm_capability(
+        &mut self,
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) -> SpdmResult {
         let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
         let send_used = self.encode_spdm_capability(&mut send_buffer);
-        self.send_message(&send_buffer[..send_used])?;
+        self.send_message(&send_buffer[..send_used], transport_encap, device_io)?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
-        let used = self.receive_message(&mut receive_buffer, false)?;
-        self.handle_spdm_capability_response(0, &send_buffer[..send_used], &receive_buffer[..used])
+        let used = self.receive_message(&mut receive_buffer, false, transport_encap, device_io)?;
+        self.handle_spdm_capability_response(
+            0,
+            &send_buffer[..send_used],
+            &receive_buffer[..used],
+            transport_encap,
+            device_io,
+        )
     }
 
     pub fn encode_spdm_capability(&mut self, buf: &mut [u8]) -> usize {
@@ -43,6 +53,8 @@ impl<'a> RequesterContext<'a> {
         session_id: u32,
         send_buffer: &[u8],
         receive_buffer: &[u8],
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
     ) -> SpdmResult {
         let mut reader = Reader::init(receive_buffer);
         match SpdmMessageHeader::read(&mut reader) {
@@ -98,6 +110,8 @@ impl<'a> RequesterContext<'a> {
                             receive_buffer,
                             SpdmRequestResponseCode::SpdmRequestGetCapabilities,
                             SpdmRequestResponseCode::SpdmResponseCapabilities,
+                            transport_encap,
+                            device_io,
                         );
                         match erm {
                             Ok(rm) => {
@@ -107,6 +121,8 @@ impl<'a> RequesterContext<'a> {
                                     session_id,
                                     send_buffer,
                                     &receive_buffer[..used],
+                                    transport_encap,
+                                    device_io,
                                 )
                             }
                             _ => spdm_result_err!(EINVAL),
@@ -137,22 +153,17 @@ mod tests_requester {
 
         crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester = FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
+
+        let mut requester = RequesterContext::new(req_config_info, req_provision_info);
 
         requester.common.reset_runtime_info();
         requester.common.negotiate_info.measurement_hash_sel =
@@ -161,7 +172,9 @@ mod tests_requester {
         requester.common.negotiate_info.base_asym_sel =
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384;
 
-        let status = requester.send_receive_spdm_capability().is_ok();
+        let status = requester
+            .send_receive_spdm_capability(pcidoe_transport_encap2, &mut device_io_requester)
+            .is_ok();
         assert!(status);
     }
 }

--- a/spdmlib/src/requester/get_version_req.rs
+++ b/spdmlib/src/requester/get_version_req.rs
@@ -7,15 +7,25 @@ use crate::message::*;
 use crate::protocol::*;
 use crate::requester::*;
 
-impl<'a> RequesterContext<'a> {
-    pub fn send_receive_spdm_version(&mut self) -> SpdmResult {
+impl RequesterContext {
+    pub fn send_receive_spdm_version(
+        &mut self,
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) -> SpdmResult {
         let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
         let send_used = self.encode_spdm_version(&mut send_buffer);
-        self.send_message(&send_buffer[..send_used])?;
+        self.send_message(&send_buffer[..send_used], transport_encap, device_io)?;
 
         let mut receive_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
-        let used = self.receive_message(&mut receive_buffer, false)?;
-        self.handle_spdm_version_response(0, &send_buffer[..send_used], &receive_buffer[..used])
+        let used = self.receive_message(&mut receive_buffer, false, transport_encap, device_io)?;
+        self.handle_spdm_version_response(
+            0,
+            &send_buffer[..send_used],
+            &receive_buffer[..used],
+            transport_encap,
+            device_io,
+        )
     }
 
     pub fn encode_spdm_version(&mut self, buf: &mut [u8]) -> usize {
@@ -36,6 +46,8 @@ impl<'a> RequesterContext<'a> {
         session_id: u32,
         send_buffer: &[u8],
         receive_buffer: &[u8],
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
     ) -> SpdmResult {
         let mut reader = Reader::init(receive_buffer);
         match SpdmMessageHeader::read(&mut reader) {
@@ -111,6 +123,8 @@ impl<'a> RequesterContext<'a> {
                         receive_buffer,
                         SpdmRequestResponseCode::SpdmRequestGetVersion,
                         SpdmRequestResponseCode::SpdmResponseVersion,
+                        transport_encap,
+                        device_io,
                     );
                     match erm {
                         Ok(rm) => {
@@ -120,6 +134,8 @@ impl<'a> RequesterContext<'a> {
                                 session_id,
                                 send_buffer,
                                 &receive_buffer[..used],
+                                transport_encap,
+                                device_io,
                             )
                         }
                         _ => spdm_result_err!(EINVAL),
@@ -149,24 +165,21 @@ mod tests_requester {
 
         crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut responder = responder::ResponderContext::new(
-            &mut device_io_responder,
-            pcidoe_transport_encap,
-            rsp_config_info,
-            rsp_provision_info,
-        );
+        let mut responder = responder::ResponderContext::new(rsp_config_info, rsp_provision_info);
 
         let pcidoe_transport_encap2 = &mut PciDoeTransportEncap {};
-        let mut device_io_requester = FakeSpdmDeviceIo::new(&shared_buffer, &mut responder);
-
-        let mut requester = RequesterContext::new(
-            &mut device_io_requester,
-            pcidoe_transport_encap2,
-            req_config_info,
-            req_provision_info,
+        let mut device_io_requester = FakeSpdmDeviceIo::new(
+            &shared_buffer,
+            &mut responder,
+            pcidoe_transport_encap,
+            &mut device_io_responder,
         );
 
-        let status = requester.send_receive_spdm_version().is_ok();
+        let mut requester = RequesterContext::new(req_config_info, req_provision_info);
+
+        let status = requester
+            .send_receive_spdm_version(pcidoe_transport_encap2, &mut device_io_requester)
+            .is_ok();
         assert!(status);
     }
 }

--- a/spdmlib/src/responder/algorithm_rsp.rs
+++ b/spdmlib/src/responder/algorithm_rsp.rs
@@ -3,17 +3,24 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use crate::common::SpdmCodec;
+use crate::common::SpdmDeviceIo;
+use crate::common::SpdmTransportEncap;
 use crate::crypto;
 use crate::message::*;
 use crate::protocol::*;
 use crate::responder::*;
 
-impl<'a> ResponderContext<'a> {
-    pub fn handle_spdm_algorithm(&mut self, bytes: &[u8]) {
+impl ResponderContext {
+    pub fn handle_spdm_algorithm(
+        &mut self,
+        bytes: &[u8],
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) {
         let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
         let mut writer = Writer::init(&mut send_buffer);
         self.write_spdm_algorithm(bytes, &mut writer);
-        let _ = self.send_message(writer.used_slice());
+        let _ = self.send_message(writer.used_slice(), transport_encap, device_io);
     }
 
     pub fn write_spdm_algorithm(&mut self, bytes: &[u8], writer: &mut Writer) {
@@ -226,12 +233,7 @@ mod tests_responder {
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
 
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            pcidoe_transport_encap,
-            config_info,
-            provision_info,
-        );
+        let mut context = responder::ResponderContext::new(config_info, provision_info);
 
         context.common.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion11;
 
@@ -267,7 +269,7 @@ mod tests_responder {
         bytes.copy_from_slice(&spdm_message_header[0..]);
         bytes[2..].copy_from_slice(&negotiate_algorithms[0..1022]);
 
-        context.handle_spdm_algorithm(bytes);
+        context.handle_spdm_algorithm(bytes, pcidoe_transport_encap, &mut socket_io_transport);
 
         let data = context.common.runtime_info.message_a.as_ref();
         let u8_slice = &mut [0u8; 2048];

--- a/spdmlib/src/responder/capability_rsp.rs
+++ b/spdmlib/src/responder/capability_rsp.rs
@@ -3,16 +3,23 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use crate::common::SpdmCodec;
+use crate::common::SpdmDeviceIo;
+use crate::common::SpdmTransportEncap;
 use crate::message::*;
 use crate::protocol::*;
 use crate::responder::*;
 
-impl<'a> ResponderContext<'a> {
-    pub fn handle_spdm_capability(&mut self, bytes: &[u8]) {
+impl ResponderContext {
+    pub fn handle_spdm_capability(
+        &mut self,
+        bytes: &[u8],
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) {
         let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
         let mut writer = Writer::init(&mut send_buffer);
         self.write_spdm_capability_response(bytes, &mut writer);
-        let _ = self.send_message(writer.used_slice());
+        let _ = self.send_message(writer.used_slice(), transport_encap, device_io);
     }
 
     pub fn write_spdm_capability_response(&mut self, bytes: &[u8], writer: &mut Writer) {
@@ -106,12 +113,7 @@ mod tests_responder {
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
         crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            pcidoe_transport_encap,
-            config_info,
-            provision_info,
-        );
+        let mut context = responder::ResponderContext::new(config_info, provision_info);
         let spdm_message_header = &mut [0u8; 1024];
         let mut writer = Writer::init(spdm_message_header);
         let value = SpdmMessageHeader {
@@ -131,7 +133,7 @@ mod tests_responder {
         let bytes = &mut [0u8; 1024];
         bytes.copy_from_slice(&spdm_message_header[0..]);
         bytes[2..].copy_from_slice(&capabilities[0..1022]);
-        context.handle_spdm_capability(bytes);
+        context.handle_spdm_capability(bytes, pcidoe_transport_encap, &mut socket_io_transport);
 
         let rsp_capabilities = SpdmResponseCapabilityFlags::CERT_CAP
             | SpdmResponseCapabilityFlags::CHAL_CAP

--- a/spdmlib/src/responder/key_update_rsp.rs
+++ b/spdmlib/src/responder/key_update_rsp.rs
@@ -3,17 +3,31 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use crate::common::SpdmCodec;
+use crate::common::SpdmDeviceIo;
+use crate::common::SpdmTransportEncap;
 use crate::message::*;
 use crate::responder::*;
 
-impl<'a> ResponderContext<'a> {
-    pub fn handle_spdm_key_update(&mut self, session_id: u32, bytes: &[u8]) {
+impl ResponderContext {
+    pub fn handle_spdm_key_update(
+        &mut self,
+        session_id: u32,
+        bytes: &[u8],
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) {
         let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
         let mut writer = Writer::init(&mut send_buffer);
         if self.write_spdm_key_update_response(session_id, bytes, &mut writer) {
-            let _ = self.send_secured_message(session_id, writer.used_slice(), false);
+            let _ = self.send_secured_message(
+                session_id,
+                writer.used_slice(),
+                false,
+                transport_encap,
+                device_io,
+            );
         } else {
-            let _ = self.send_message(writer.used_slice());
+            let _ = self.send_message(writer.used_slice(), transport_encap, device_io);
         }
     }
 
@@ -89,12 +103,7 @@ mod tests_responder {
         let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            pcidoe_transport_encap,
-            config_info,
-            provision_info,
-        );
+        let mut context = responder::ResponderContext::new(config_info, provision_info);
 
         crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
@@ -151,7 +160,12 @@ mod tests_responder {
         bytes.copy_from_slice(&spdm_message_header[0..]);
         bytes[2..].copy_from_slice(&key_exchange[0..1022]);
 
-        context.handle_spdm_key_update(session_id, bytes);
+        context.handle_spdm_key_update(
+            session_id,
+            bytes,
+            pcidoe_transport_encap,
+            &mut socket_io_transport,
+        );
     }
 
     #[test]
@@ -161,12 +175,7 @@ mod tests_responder {
         crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
         let shared_buffer = SharedBuffer::new();
         let mut socket_io_transport = FakeSpdmDeviceIoReceve::new(&shared_buffer);
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            pcidoe_transport_encap,
-            config_info,
-            provision_info,
-        );
+        let mut context = responder::ResponderContext::new(config_info, provision_info);
 
         let rsp_session_id = 0xFFFEu16;
         let session_id = (0xffu32 << 16) + rsp_session_id as u32;
@@ -220,6 +229,11 @@ mod tests_responder {
         bytes.copy_from_slice(&spdm_message_header[0..]);
         bytes[2..].copy_from_slice(&key_exchange[0..1022]);
 
-        context.handle_spdm_key_update(session_id, bytes);
+        context.handle_spdm_key_update(
+            session_id,
+            bytes,
+            pcidoe_transport_encap,
+            &mut socket_io_transport,
+        );
     }
 }

--- a/spdmlib/src/responder/psk_exchange_rsp.rs
+++ b/spdmlib/src/responder/psk_exchange_rsp.rs
@@ -4,7 +4,9 @@
 
 use crate::common::opaque::SpdmOpaqueStruct;
 use crate::common::SpdmCodec;
+use crate::common::SpdmDeviceIo;
 use crate::common::SpdmOpaqueSupport;
+use crate::common::SpdmTransportEncap;
 use crate::crypto;
 use crate::error::{spdm_result_err, SpdmResult};
 use crate::message::*;
@@ -17,18 +19,24 @@ use alloc::boxed::Box;
 #[cfg(not(feature = "hashed-transcript-data"))]
 use crate::common::ManagedBuffer;
 
-impl<'a> ResponderContext<'a> {
-    pub fn handle_spdm_psk_exchange(&mut self, bytes: &[u8]) -> SpdmResult {
+impl ResponderContext {
+    pub fn handle_spdm_psk_exchange(
+        &mut self,
+        bytes: &[u8],
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) -> SpdmResult {
         let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
         let mut writer = Writer::init(&mut send_buffer);
-        self.write_spdm_psk_exchange_response(bytes, &mut writer)?;
-        self.send_message(writer.used_slice())
+        self.write_spdm_psk_exchange_response(bytes, &mut writer, transport_encap)?;
+        self.send_message(writer.used_slice(), transport_encap, device_io)
     }
 
     pub fn write_spdm_psk_exchange_response(
         &mut self,
         bytes: &[u8],
         writer: &mut Writer,
+        transport_encap: &mut dyn SpdmTransportEncap,
     ) -> SpdmResult {
         let mut reader = Reader::init(bytes);
         SpdmMessageHeader::read(&mut reader);
@@ -190,8 +198,8 @@ impl<'a> ResponderContext<'a> {
         let dhe_algo = self.common.negotiate_info.dhe_sel;
         let aead_algo = self.common.negotiate_info.aead_sel;
         let key_schedule_algo = self.common.negotiate_info.key_schedule_sel;
-        let sequence_number_count = self.common.transport_encap.get_sequence_number_count();
-        let max_random_count = self.common.transport_encap.get_max_random_count();
+        let sequence_number_count = transport_encap.get_sequence_number_count();
+        let max_random_count = transport_encap.get_max_random_count();
 
         let spdm_version_sel = self.common.negotiate_info.spdm_version_sel;
         let session = self.common.get_next_avaiable_session();
@@ -293,12 +301,7 @@ mod tests_responder {
 
         crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
 
-        let mut context = responder::ResponderContext::new(
-            &mut socket_io_transport,
-            pcidoe_transport_encap,
-            config_info,
-            provision_info,
-        );
+        let mut context = responder::ResponderContext::new(config_info, provision_info);
         context.common.provision_info.my_cert_chain = Some(SpdmCertChainData {
             data_size: 512u16,
             data: [0u8; config::MAX_SPDM_CERT_CHAIN_DATA_SIZE],
@@ -343,6 +346,10 @@ mod tests_responder {
         let bytes = &mut [0u8; 1024];
         bytes.copy_from_slice(&spdm_message_header[0..]);
         bytes[2..].copy_from_slice(&challenge[0..1022]);
-        let _ = context.handle_spdm_psk_exchange(bytes);
+        let _ = context.handle_spdm_psk_exchange(
+            bytes,
+            pcidoe_transport_encap,
+            &mut socket_io_transport,
+        );
     }
 }

--- a/spdmlib/src/responder/respond_if_ready_rsp.rs
+++ b/spdmlib/src/responder/respond_if_ready_rsp.rs
@@ -3,15 +3,22 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use crate::common::SpdmCodec;
+use crate::common::SpdmDeviceIo;
+use crate::common::SpdmTransportEncap;
 use crate::message::*;
 use crate::responder::*;
 
-impl<'a> ResponderContext<'a> {
-    pub fn handle_spdm_respond_if_ready(&mut self, bytes: &[u8]) {
+impl ResponderContext {
+    pub fn handle_spdm_respond_if_ready(
+        &mut self,
+        bytes: &[u8],
+        transport_encap: &mut dyn SpdmTransportEncap,
+        device_io: &mut dyn SpdmDeviceIo,
+    ) {
         let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
         let mut writer = Writer::init(&mut send_buffer);
         self.write_spdm_respond_if_ready_response(bytes, &mut writer);
-        let _ = self.send_message(writer.used_slice());
+        let _ = self.send_message(writer.used_slice(), transport_encap, device_io);
     }
 
     pub fn write_spdm_respond_if_ready_response(&mut self, bytes: &[u8], writer: &mut Writer) {

--- a/spdmlib/tests/common/testlib.rs
+++ b/spdmlib/tests/common/testlib.rs
@@ -24,17 +24,9 @@ pub fn get_test_key_directory() -> PathBuf {
     crate_dir.to_path_buf()
 }
 
-pub fn new_context<'a>(
-    my_spdm_device_io: &'a mut MySpdmDeviceIo,
-    pcidoe_transport_encap: &'a mut PciDoeTransportEncap,
-) -> SpdmContext<'a> {
+pub fn new_context<'a>() -> SpdmContext {
     let (config_info, provision_info) = create_info();
-    let mut context = SpdmContext::new(
-        my_spdm_device_io,
-        pcidoe_transport_encap,
-        config_info,
-        provision_info,
-    );
+    let mut context = SpdmContext::new(config_info, provision_info);
     context.negotiate_info.opaque_data_support = SpdmOpaqueSupport::OPAQUE_DATA_FMT1;
     context
 }
@@ -328,11 +320,11 @@ fn sign_ecdsa_asym_algo(
 
 pub struct FakeSpdmDeviceIo<'a> {
     pub data: &'a SharedBuffer,
-    pub responder: &'a mut responder::ResponderContext<'a>,
+    pub responder: &'a mut responder::ResponderContext,
 }
 
 impl<'a> FakeSpdmDeviceIo<'a> {
-    pub fn new(data: &'a SharedBuffer, responder: &'a mut responder::ResponderContext<'a>) -> Self {
+    pub fn new(data: &'a SharedBuffer, responder: &'a mut responder::ResponderContext) -> Self {
         FakeSpdmDeviceIo { data, responder }
     }
 }
@@ -348,9 +340,9 @@ impl SpdmDeviceIo for FakeSpdmDeviceIo<'_> {
         self.data.set_buffer(buffer);
         log::info!("requester send    RAW - {:02x?}\n", buffer);
 
-        if self.responder.process_message(ST1, &[0]).is_err() {
-            return spdm_result_err!(ENOMEM);
-        }
+        // if self.responder.process_message(ST1, &[0], None, None).is_err() {
+        //     return spdm_result_err!(ENOMEM);
+        // }
         Ok(())
     }
 

--- a/spdmlib/tests/test_library.rs
+++ b/spdmlib/tests/test_library.rs
@@ -28,7 +28,7 @@ fn test_case0_spdm_opaque_struct() {
 
     let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
     let my_spdm_device_io = &mut MySpdmDeviceIo;
-    let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);
+    let mut context = new_context();
 
     value.spdm_encode(&mut context, &mut writer);
     let mut reader = Reader::init(u8_slice);
@@ -52,7 +52,7 @@ fn test_case0_spdm_digest_struct() {
 
     let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
     let my_spdm_device_io = &mut MySpdmDeviceIo;
-    let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);
+    let mut context = new_context();
     context.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_512;
     value.spdm_encode(&mut context, &mut writer);
     let mut reader = Reader::init(u8_slice);
@@ -75,7 +75,7 @@ fn test_case0_spdm_signature_struct() {
 
     let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
     let my_spdm_device_io = &mut MySpdmDeviceIo;
-    let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);
+    let mut context = new_context();
     context.negotiate_info.base_asym_sel = SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096;
 
     value.spdm_encode(&mut context, &mut writer);
@@ -104,7 +104,7 @@ fn test_case0_spdm_cert_chain() {
 
     let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
     let my_spdm_device_io = &mut MySpdmDeviceIo;
-    let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);
+    let mut context = new_context();
     context.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_512;
 
     value.spdm_encode(&mut context, &mut writer);
@@ -150,7 +150,7 @@ fn test_case0_spdm_measurement_record_structure() {
 
     let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
     let my_spdm_device_io = &mut MySpdmDeviceIo;
-    let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);
+    let mut context = new_context();
 
     value.spdm_encode(&mut context, &mut writer);
     let mut reader = Reader::init(u8_slice);
@@ -190,7 +190,7 @@ fn test_case1_spdm_measurement_record_structure() {
 
     let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
     let my_spdm_device_io = &mut MySpdmDeviceIo;
-    let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);
+    let mut context = new_context();
     value.spdm_encode(&mut context, &mut writer);
 }
 #[test]
@@ -205,7 +205,7 @@ fn test_case0_spdm_dhe_exchange_struct() {
 
     let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
     let my_spdm_device_io = &mut MySpdmDeviceIo;
-    let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);
+    let mut context = new_context();
     context.negotiate_info.dhe_sel = SpdmDheAlgo::FFDHE_4096;
 
     value.spdm_encode(&mut context, &mut writer);
@@ -238,7 +238,7 @@ fn test_case0_spdm_dmtf_measurement_structure() {
 
     let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
     let my_spdm_device_io = &mut MySpdmDeviceIo;
-    let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);
+    let mut context = new_context();
     for i in 0..5 {
         value.r#type = r#type[i];
         if i < 2 {
@@ -282,7 +282,7 @@ fn test_case0_spdm_measurement_block_structure() {
     };
     let pcidoe_transport_encap = &mut PciDoeTransportEncap {};
     let my_spdm_device_io = &mut MySpdmDeviceIo;
-    let mut context = new_context(my_spdm_device_io, pcidoe_transport_encap);
+    let mut context = new_context();
     context.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_512;
 
     value.spdm_encode(&mut context, &mut writer);

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -159,22 +159,26 @@ fn test_spdm(
         default_version: SpdmVersion::SpdmVersion12,
     };
 
-    let mut context = requester::RequesterContext::new(
-        socket_io_transport,
-        transport_encap,
-        config_info,
-        provision_info,
-    );
+    let mut context = requester::RequesterContext::new(config_info, provision_info);
 
-    if context.init_connection().is_err() {
+    if context
+        .init_connection(transport_encap, socket_io_transport)
+        .is_err()
+    {
         panic!("init_connection failed!");
     }
 
-    if context.send_receive_spdm_digest(None).is_err() {
+    if context
+        .send_receive_spdm_digest(None, transport_encap, socket_io_transport)
+        .is_err()
+    {
         panic!("send_receive_spdm_digest failed!");
     }
 
-    if context.send_receive_spdm_certificate(None, 0).is_err() {
+    if context
+        .send_receive_spdm_certificate(None, 0, transport_encap, socket_io_transport)
+        .is_err()
+    {
         panic!("send_receive_spdm_certificate failed!");
     }
 
@@ -182,6 +186,8 @@ fn test_spdm(
         .send_receive_spdm_challenge(
             0,
             SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeNone,
+            transport_encap,
+            socket_io_transport,
         )
         .is_err()
     {
@@ -198,6 +204,8 @@ fn test_spdm(
             SpdmMeasurementOperation::SpdmMeasurementRequestAll,
             &mut total_number,
             &mut spdm_measurement_record_structure,
+            transport_encap,
+            socket_io_transport,
         )
         .is_err()
     {
@@ -208,6 +216,8 @@ fn test_spdm(
         false,
         0,
         SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeNone,
+        transport_encap,
+        socket_io_transport,
     );
     if let Ok(session_id) = result {
         info!("\nSession established ... session_id {:0x?}\n", session_id);
@@ -232,12 +242,20 @@ fn test_spdm(
             response_direction.salt.as_ref()
         );
 
-        if context.send_receive_spdm_heartbeat(session_id).is_err() {
+        if context
+            .send_receive_spdm_heartbeat(session_id, transport_encap, socket_io_transport)
+            .is_err()
+        {
             panic!("send_receive_spdm_heartbeat failed");
         }
 
         if context
-            .send_receive_spdm_key_update(session_id, SpdmKeyUpdateOperation::SpdmUpdateAllKeys)
+            .send_receive_spdm_key_update(
+                session_id,
+                SpdmKeyUpdateOperation::SpdmUpdateAllKeys,
+                transport_encap,
+                socket_io_transport,
+            )
             .is_err()
         {
             panic!("send_receive_spdm_key_update failed");
@@ -251,24 +269,37 @@ fn test_spdm(
                 SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber,
                 &mut total_number,
                 &mut spdm_measurement_record_structure,
+                transport_encap,
+                socket_io_transport,
             )
             .is_err()
         {
             panic!("send_receive_spdm_measurement failed");
         }
 
-        if context.send_receive_spdm_digest(Some(session_id)).is_err() {
+        if context
+            .send_receive_spdm_digest(Some(session_id), transport_encap, socket_io_transport)
+            .is_err()
+        {
             panic!("send_receive_spdm_digest failed");
         }
 
         if context
-            .send_receive_spdm_certificate(Some(session_id), 0)
+            .send_receive_spdm_certificate(
+                Some(session_id),
+                0,
+                transport_encap,
+                socket_io_transport,
+            )
             .is_err()
         {
             panic!("send_receive_spdm_certificate failed");
         }
 
-        if context.end_session(session_id).is_err() {
+        if context
+            .end_session(session_id, transport_encap, socket_io_transport)
+            .is_err()
+        {
             panic!("end_session failed");
         }
     } else {
@@ -279,9 +310,14 @@ fn test_spdm(
         true,
         0,
         SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeNone,
+        transport_encap,
+        socket_io_transport,
     );
     if let Ok(session_id) = result {
-        if context.end_session(session_id).is_err() {
+        if context
+            .end_session(session_id, transport_encap, socket_io_transport)
+            .is_err()
+        {
             panic!("\nSession session_id is err\n");
         }
     } else {

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -231,16 +231,11 @@ fn handle_message(
     };
 
     spdmlib::crypto::asym_sign::register(ASYM_SIGN_IMPL.clone());
-    let mut context = responder::ResponderContext::new(
-        &mut socket_io_transport,
-        transport_encap,
-        config_info,
-        provision_info,
-    );
+    let mut context = responder::ResponderContext::new(config_info, provision_info);
     loop {
         // if failed, receieved message can't be processed. then the message will need caller to deal.
         // now caller need to deal with message in context.
-        let res = context.process_message(ST1, &[0]);
+        let res = context.process_message(ST1, &[0], transport_encap, &mut socket_io_transport);
         match res {
             Ok(spdm_result) => {
                 if spdm_result {


### PR DESCRIPTION
1. remove 2 mutable refs from SpdmContext (Issue#380)
2. update spdm emulators to meet the changes of issue#380.