### PR TITLE
Remove tdisp from rust-spdm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ default-members = [
     "codec",
     "test/spdm-requester-emu",
     "test/spdm-responder-emu",
-    "tdisp",
 ]
 
 members = [
@@ -13,7 +12,6 @@ members = [
     "codec",
     "test/spdm-requester-emu",
     "test/spdm-responder-emu",
-    "tdisp",
 
     "fuzz-target/responder/version_rsp",
     "fuzz-target/responder/capability_rsp",
@@ -51,7 +49,8 @@ members = [
 exclude = [
     "external/ring",
     "external/webpki",
-    "fuzz-target/"
+    "fuzz-target/",
+    "tdisp"
 ]
 
 resolver = "2"

--- a/sh_script/build.sh
+++ b/sh_script/build.sh
@@ -68,9 +68,6 @@ build() {
     
     echo "Building spdm-responder-emu..."
     echo_command cargo build -p spdm-responder-emu
-    
-    echo "Building tdisp..."
-    echo_command cargo build -p tdisp
 }
 
 SPDM_EMU_PRE_BUILD_NAME=${SPDM_EMU_PRE_BUILD_NAME:-spdm-emu-v2.2.0.tar.bz2}


### PR DESCRIPTION
ISSUE: https://github.com/jyao1/rust-spdm/issues/396

tdisp has conflicts with the updates by issue#380 (remove mutable refs from SpdmContext). Further more, tdisp itself needs other refactors. So it is temporarily removed from Cargo.toml and build.sh. A new issue will be created to track it is added back.