### PR TITLE
vendor defined request/response should not be treated as app message.

### DIFF
--- a/spdmlib/src/requester/vendor_req.rs
+++ b/spdmlib/src/requester/vendor_req.rs
@@ -32,7 +32,7 @@ impl<'a> RequesterContext<'a> {
         };
         request.spdm_encode(&mut self.common, &mut writer);
         let used = writer.used();
-        self.send_secured_message(session_id, &send_buffer[..used], true)?;
+        self.send_secured_message(session_id, &send_buffer[..used], false)?;
 
         //receive
         let mut receive_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];

--- a/spdmlib/src/responder/vendor_rsp.rs
+++ b/spdmlib/src/responder/vendor_rsp.rs
@@ -37,7 +37,7 @@ impl<'a> ResponderContext<'a> {
         };
         response.spdm_encode(&mut self.common, &mut writer);
         let used = writer.used();
-        let _ = self.send_secured_message(session_id, &send_buffer[..used], true);
+        let _ = self.send_secured_message(session_id, &send_buffer[..used], false);
     }
 
     pub fn respond_to_vendor_defined_request<F>(


### PR DESCRIPTION
fix #395 