### PR TITLE
add slot_id check in certificate_rsp.

### DIFF
--- a/spdmlib/src/responder/certificate_rsp.rs
+++ b/spdmlib/src/responder/certificate_rsp.rs
@@ -29,6 +29,10 @@ impl<'a> ResponderContext<'a> {
             SpdmGetCertificateRequestPayload::spdm_read(&mut self.common, &mut reader);
         if let Some(get_certificate) = &get_certificate {
             debug!("!!! get_certificate : {:02x?}\n", get_certificate);
+            if get_certificate.slot_id != 0 {
+                self.write_spdm_error(SpdmErrorCode::SpdmErrorInvalidRequest, 0, writer);
+                return;
+            }
         } else {
             error!("!!! get_certificate : fail !!!\n");
             self.write_spdm_error(SpdmErrorCode::SpdmErrorInvalidRequest, 0, writer);


### PR DESCRIPTION
Currently, no matter what request to get certificate at any slot id, the same certificate is returned. This patch add a check to the slot id. Currently, responder supports only slot id 0.