### PR TITLE
stack size opt: get_version/version.

### DIFF
--- a/spdmlib/etc/config.json
+++ b/spdmlib/etc/config.json
@@ -1,6 +1,10 @@
 {
     "__usage": "This helps generate compile-time constant sizes for SPDM arrays. See src/config.rs generated for details.",
-    "max_version_count": 3,
+    "spdm_version_config": {
+        "is_spdm_version_10_supported": false,
+        "is_spdm_version_11_supported": false,
+        "is_spdm_version_12_supported": true
+    },
     "algo_config": {
         "max_ext_asym_algo_count": 0,
         "max_ext_hash_algo_count": 0,

--- a/spdmlib/src/requester/get_version_req.rs
+++ b/spdmlib/src/requester/get_version_req.rs
@@ -12,11 +12,11 @@ use crate::requester::*;
 
 impl<'a> RequesterContext<'a> {
     pub fn send_receive_spdm_version(&mut self) -> SpdmResult {
-        let mut send_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
+        let mut send_buffer = [0u8; config::MAX_GET_VERSION_REQUEST_MESSAGE_BUFFER_SIZE];
         let send_used = self.encode_spdm_version(&mut send_buffer);
         self.send_message(&send_buffer[..send_used])?;
 
-        let mut receive_buffer = [0u8; config::MAX_SPDM_MESSAGE_BUFFER_SIZE];
+        let mut receive_buffer = [0u8; config::MAX_VERSION_RESPONSE_MESSAGE_BUFFER_SIZE];
         let used = self.receive_message(&mut receive_buffer, false)?;
         self.handle_spdm_version_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }


### PR DESCRIPTION
This is a splited part of PR #416
And has **no contribution** to reducing the max stack size usage **yet**.