### PR TITLE
spdmlib/responder: Fix error when call dispatch_secured_app_message

### DIFF
--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -115,7 +115,7 @@ impl<'a> ResponderContext<'a> {
                             } else {
                                 Ok(self.dispatch_secured_app_message(
                                     session_id,
-                                    &receive_buffer[0..used],
+                                    &spdm_buffer[..decode_size],
                                     auxiliary_app_data,
                                 ))
                             }


### PR DESCRIPTION
Fix #562

The input data of dispatch_secured_app_message shall be spdm_buffer[0..decode_size], not receive_buffer[0..used].

spdm_buffer contains the decrypted data, while receive_buffer contains the raw SPDM message, including the encrypted data.