### PR TITLE
Reset context instead of runtime_info when GET_VERSION

### DIFF
--- a/spdmlib/src/responder/version_rsp.rs
+++ b/spdmlib/src/responder/version_rsp.rs
@@ -38,7 +38,7 @@ impl<'a> ResponderContext<'a> {
         }
 
         // clear cache data
-        self.common.reset_runtime_info();
+        self.common.reset_context();
 
         if self
             .common


### PR DESCRIPTION
Fix #560

According to DSP0274 1.2 Section 10.2:
"After receiving a valid GET_VERSION request, the Responder shall invalidate state and data associated with all previous requests from the same Requester. All active sessions between the Requester and the Responder are terminated and information (such as session keys, session IDs) for those sessions should not be used anymore. Additionally, this message shall clear the previously Negotiated State, if any, in both the Requester and its corresponding Responder."