### PR TITLE
Update mod app_message_handler to pub

### DIFF
--- a/spdmlib/src/responder/mod.rs
+++ b/spdmlib/src/responder/mod.rs
@@ -22,7 +22,7 @@ mod version_rsp;
 mod error_rsp;
 mod vendor_rsp;
 
-mod app_message_handler;
+pub mod app_message_handler;
 
 pub use context::ResponderContext;
 


### PR DESCRIPTION
Fix #561

app_message_handler shall be declared as public otherwise it cannot be used outside of rust-spdm.