### PR TITLE
Fuzz enable libfuzzer

### DIFF
--- a/fuzz-target/fuzzlib/Cargo.toml
+++ b/fuzz-target/fuzzlib/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-afl = "=0.12.12"
+afl = { version = "=0.12.12", optional = true }
 spdm-emu = { path = "../../test/spdm-emu", default-features = false }
 spdmlib = { path = "../../spdmlib", default-features = false, features=["spdm-ring"] }
 codec = { path = "../../codec" }
@@ -20,5 +20,5 @@ ring = { git="https://github.com/jyao1/ring", branch="uefi_support"}
 flexi_logger = "0.18.0"
 
 [features]
-default = ["hashed-transcript-data"]
+default = ["hashed-transcript-data", "afl"]
 hashed-transcript-data = ["spdmlib/hashed-transcript-data"]

--- a/fuzz-target/requester/capability_req/src/main.rs
+++ b/fuzz-target/requester/capability_req/src/main.rs
@@ -36,6 +36,7 @@ fn fuzz_send_receive_spdm_capability(fuzzdata: &[u8]) {
     let _ = requester.send_receive_spdm_capability();
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/certificate_req/src/main.rs
+++ b/fuzz-target/requester/certificate_req/src/main.rs
@@ -317,6 +317,7 @@ fn fuzz_send_receive_spdm_certificate(fuzzdata: &[u8]) {
     }
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/challenge_req/src/main.rs
+++ b/fuzz-target/requester/challenge_req/src/main.rs
@@ -86,6 +86,7 @@ fn fuzz_send_receive_spdm_challenge(fuzzdata: &[u8]) {
         .is_err();
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/digest_req/src/main.rs
+++ b/fuzz-target/requester/digest_req/src/main.rs
@@ -67,6 +67,7 @@ fn fuzz_send_receive_spdm_digest(fuzzdata: &[u8]) {
     let _ = requester.send_receive_spdm_digest(None).is_err();
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/end_session_req/src/main.rs
+++ b/fuzz-target/requester/end_session_req/src/main.rs
@@ -120,6 +120,7 @@ fn fuzz_send_receive_spdm_end_session(fuzzdata: &[u8]) {
     }
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/finish_req/src/main.rs
+++ b/fuzz-target/requester/finish_req/src/main.rs
@@ -380,6 +380,7 @@ fn fuzz_send_receive_spdm_finish(fuzzdata: &[u8]) {
     }
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/heartbeat_req/src/main.rs
+++ b/fuzz-target/requester/heartbeat_req/src/main.rs
@@ -124,6 +124,7 @@ fn fuzz_send_receive_spdm_heartbeat(fuzzdata: &[u8]) {
     }
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/key_exchange_req/src/main.rs
+++ b/fuzz-target/requester/key_exchange_req/src/main.rs
@@ -152,6 +152,7 @@ fn fuzz_send_receive_spdm_key_exchange(fuzzdata: &[u8]) {
     }
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/key_update_req/src/main.rs
+++ b/fuzz-target/requester/key_update_req/src/main.rs
@@ -164,6 +164,7 @@ fn fuzz_send_receive_spdm_key_update(fuzzdata: &[u8]) {
     }
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/measurement_req/src/main.rs
+++ b/fuzz-target/requester/measurement_req/src/main.rs
@@ -681,6 +681,7 @@ fn fuzz_send_receive_spdm_measurement(fuzzdata: &[u8]) {
     }
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/psk_exchange_req/src/main.rs
+++ b/fuzz-target/requester/psk_exchange_req/src/main.rs
@@ -84,6 +84,7 @@ fn fuzz_send_receive_spdm_psk_exchange(fuzzdata: &[u8]) {
     }
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/psk_finish_req/src/main.rs
+++ b/fuzz-target/requester/psk_finish_req/src/main.rs
@@ -93,6 +93,7 @@ fn fuzz_send_receive_spdm_psk_finish(fuzzdata: &[u8]) {
     let _ = requester.send_receive_spdm_psk_finish(4294901758);
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/requester/version_req/src/main.rs
+++ b/fuzz-target/requester/version_req/src/main.rs
@@ -46,6 +46,7 @@ fn fuzz_send_receive_spdm_version(fuzzdata: &[u8]) {
     }
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/algorithm_rsp/src/main.rs
+++ b/fuzz-target/responder/algorithm_rsp/src/main.rs
@@ -30,6 +30,7 @@ fn fuzz_handle_spdm_algorithm(data: &[u8]) {
     context.handle_spdm_algorithm(data);
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/capability_rsp/src/main.rs
+++ b/fuzz-target/responder/capability_rsp/src/main.rs
@@ -28,6 +28,7 @@ fn fuzz_handle_spdm_capability(data: &[u8]) {
     context.handle_spdm_capability(data);
 }
 
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/certificate_rsp/src/main.rs
+++ b/fuzz-target/responder/certificate_rsp/src/main.rs
@@ -46,6 +46,8 @@ fn fuzz_handle_spdm_certificate(data: &[u8]) {
 
     context.handle_spdm_certificate(data, None);
 }
+
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/challenge_rsp/src/main.rs
+++ b/fuzz-target/responder/challenge_rsp/src/main.rs
@@ -45,6 +45,8 @@ fn fuzz_handle_spdm_challenge(data: &[u8]) {
     }
     context.handle_spdm_challenge(data);
 }
+
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/digest_rsp/src/main.rs
+++ b/fuzz-target/responder/digest_rsp/src/main.rs
@@ -47,6 +47,8 @@ fn fuzz_handle_spdm_digest(data: &[u8]) {
     }
     context.handle_spdm_digest(data, None);
 }
+
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/end_session_rsp/src/main.rs
+++ b/fuzz-target/responder/end_session_rsp/src/main.rs
@@ -45,6 +45,8 @@ fn fuzz_handle_spdm_end_session(data: &[u8]) {
 
     context.handle_spdm_end_session(4294901758, data);
 }
+
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/heartbeat_rsp/src/main.rs
+++ b/fuzz-target/responder/heartbeat_rsp/src/main.rs
@@ -43,6 +43,8 @@ fn fuzz_handle_spdm_heartbeat(data: &[u8]) {
 
     context.handle_spdm_heartbeat(4294901758, data);
 }
+
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/key_update_rsp/src/main.rs
+++ b/fuzz-target/responder/key_update_rsp/src/main.rs
@@ -43,6 +43,8 @@ fn fuzz_handle_spdm_key_update(data: &[u8]) {
 
     context.handle_spdm_key_update(4294901758, data);
 }
+
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/keyexchange_rsp/src/main.rs
+++ b/fuzz-target/responder/keyexchange_rsp/src/main.rs
@@ -113,6 +113,8 @@ fn fuzz_handle_spdm_key_exchange(data: &[u8]) {
         context.handle_spdm_key_exchange(data);
     }
 }
+
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/measurement_rsp/src/main.rs
+++ b/fuzz-target/responder/measurement_rsp/src/main.rs
@@ -40,6 +40,8 @@ fn fuzz_handle_spdm_measurement(data: &[u8]) {
 
     context.handle_spdm_measurement(None, data);
 }
+
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/psk_finish_rsp/src/main.rs
+++ b/fuzz-target/responder/psk_finish_rsp/src/main.rs
@@ -142,6 +142,8 @@ fn fuzz_handle_spdm_psk_finish(data: &[u8]) {
         context.handle_spdm_psk_finish(4294901758, data);
     }
 }
+
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/fuzz-target/responder/version_rsp/src/main.rs
+++ b/fuzz-target/responder/version_rsp/src/main.rs
@@ -30,6 +30,8 @@ fn fuzz_handle_spdm_version(data: &[u8]) {
     socket_io_transport.receive(&mut req_buf, 60).unwrap();
     println!("Received: {:?}", req_buf);
 }
+
+#[cfg(not(feature = "use_libfuzzer"))]
 fn main() {
     #[cfg(all(feature = "fuzzlogfile", feature = "fuzz"))]
     flexi_logger::Logger::try_with_str("info")

--- a/spdmlib/fuzz/.gitignore
+++ b/spdmlib/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/spdmlib/fuzz/Cargo.toml
+++ b/spdmlib/fuzz/Cargo.toml
@@ -1,0 +1,195 @@
+[package]
+name = "spdmlib-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+fuzzlib = { path = "../../fuzz-target/fuzzlib", default-features = false }
+
+[dependencies.spdmlib]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[features]
+default = ["hashed-transcript-data", "use_libfuzzer"]
+hashed-transcript-data = ["spdmlib/hashed-transcript-data"]
+use_libfuzzer = []
+
+[[bin]]
+name = "version_rsp"
+path = "fuzz_targets/version_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "capability_rsp"
+path = "fuzz_targets/capability_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "algorithm_rsp"
+path = "fuzz_targets/algorithm_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "digest_rsp"
+path = "fuzz_targets/digest_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "certificate_rsp"
+path = "fuzz_targets/certificate_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "challenge_rsp"
+path = "fuzz_targets/challenge_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "measurement_rsp"
+path = "fuzz_targets/measurement_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "keyexchange_rsp"
+path = "fuzz_targets/keyexchange_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "pskexchange_rsp"
+path = "fuzz_targets/pskexchange_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "finish_rsp"
+path = "fuzz_targets/finish_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "psk_finish_rsp"
+path = "fuzz_targets/psk_finish_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "heartbeat_rsp"
+path = "fuzz_targets/heartbeat_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "key_update_rsp"
+path = "fuzz_targets/key_update_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "end_session_rsp"
+path = "fuzz_targets/end_session_rsp.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "version_req"
+path = "fuzz_targets/version_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "capability_req"
+path = "fuzz_targets/capability_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "algorithm_req"
+path = "fuzz_targets/algorithm_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "digest_req"
+path = "fuzz_targets/digest_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "certificate_req"
+path = "fuzz_targets/certificate_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "challenge_req"
+path = "fuzz_targets/challenge_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "measurement_req"
+path = "fuzz_targets/measurement_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "key_exchange_req"
+path = "fuzz_targets/key_exchange_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "psk_exchange_req"
+path = "fuzz_targets/psk_exchange_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "finish_req"
+path = "fuzz_targets/finish_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "psk_finish_req"
+path = "fuzz_targets/psk_finish_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "heartbeat_req"
+path = "fuzz_targets/heartbeat_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "key_update_req"
+path = "fuzz_targets/key_update_req.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "end_session_req"
+path = "fuzz_targets/end_session_req.rs"
+test = false
+doc = false

--- a/spdmlib/fuzz/fuzz_targets/algorithm_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/algorithm_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/algorithm_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_algorithm(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/algorithm_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/algorithm_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/algorithm_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_algorithm(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/capability_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/capability_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/capability_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_capability(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/capability_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/capability_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/capability_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_capability(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/certificate_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/certificate_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/certificate_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_certificate(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/certificate_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/certificate_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/certificate_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_certificate(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/challenge_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/challenge_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/challenge_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_challenge(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/challenge_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/challenge_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/challenge_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_challenge(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/digest_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/digest_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/digest_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_digest(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/digest_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/digest_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/digest_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_digest(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/end_session_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/end_session_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/end_session_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_end_session(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/end_session_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/end_session_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/end_session_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_end_session(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/finish_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/finish_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/finish_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_finish(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/finish_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/finish_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/finish_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_finish(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/heartbeat_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/heartbeat_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/heartbeat_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_heartbeat(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/heartbeat_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/heartbeat_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/heartbeat_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_heartbeat(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/key_exchange_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/key_exchange_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/key_exchange_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_key_exchange(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/key_update_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/key_update_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/key_update_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_key_update(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/key_update_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/key_update_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/key_update_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_key_update(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/keyexchange_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/keyexchange_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/keyexchange_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_key_exchange(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/measurement_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/measurement_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/measurement_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_measurement(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/measurement_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/measurement_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/measurement_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_measurement(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/psk_exchange_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/psk_exchange_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/psk_exchange_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_psk_exchange(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/psk_finish_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/psk_finish_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/psk_finish_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_psk_finish(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/psk_finish_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/psk_finish_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/psk_finish_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_psk_finish(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/pskexchange_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/pskexchange_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/pskexchange_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_psk_exchange(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/version_req.rs
+++ b/spdmlib/fuzz/fuzz_targets/version_req.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/requester/version_req/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_send_receive_spdm_version(data);
+});

--- a/spdmlib/fuzz/fuzz_targets/version_rsp.rs
+++ b/spdmlib/fuzz/fuzz_targets/version_rsp.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+include!("../../../fuzz-target/responder/version_rsp/src/main.rs");
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    fuzz_handle_spdm_version(data);
+});


### PR DESCRIPTION
#463 

Leverage existing afl fuzzcode.

How to use:

Follow https://rust-fuzz.github.io/book/cargo-fuzz.html to setup environment.

```
cd spdmlib
cargo fuzz list
cargo fuzz run xxx
```
