### PR TITLE
Fix wrong implmentation of DHE.

### DIFF
--- a/spdmlib_crypto_mbedtls/Cargo.toml
+++ b/spdmlib_crypto_mbedtls/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 spdmlib = { path = "../spdmlib", default-features = false}
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
 spin = "0.9.8"
+zeroize = { version = "1.5.0", features = ["zeroize_derive"]}
 
 [build-dependencies]
 cc = { version = "1.0.63", default-features = false }

--- a/spdmlib_crypto_mbedtls/src/dhe_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/dhe_impl.rs
@@ -14,8 +14,10 @@ use spdmlib::crypto::{SpdmDhe, SpdmDheKeyExchange};
 use spdmlib::protocol::{
     SpdmDheAlgo, SpdmDheExchangeStruct, SpdmDheFinalKeyStruct, SPDM_MAX_DHE_KEY_SIZE,
 };
+use zeroize::ZeroizeOnDrop;
 
 const MAX_KEY_LEN: usize = 97;
+#[derive(ZeroizeOnDrop)]
 struct MbedTlsDheExchangeStruct {
     data_size: usize,
     data: [u8; MAX_KEY_LEN],
@@ -103,6 +105,7 @@ extern "C" fn f_rng(_rng_state: *mut c_void, output: *mut c_uchar, len: usize) -
     0
 }
 
+#[derive(ZeroizeOnDrop)]
 struct EphemeralPrivateKey {
     pub key_len: usize,
     pub key: [u8; MAX_KEY_LEN],

--- a/spdmlib_crypto_mbedtls/src/dhe_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/dhe_impl.rs
@@ -12,11 +12,11 @@ use super::ffi::{
 use core::ffi::{c_int, c_uchar, c_void};
 use spdmlib::crypto::{SpdmDhe, SpdmDheKeyExchange};
 use spdmlib::protocol::{
-    SpdmDheAlgo, SpdmDheExchangeStruct, SpdmDheFinalKeyStruct, SPDM_MAX_DHE_KEY_SIZE,
+    SpdmDheAlgo, SpdmDheExchangeStruct, SpdmDheFinalKeyStruct, ECDSA_ECC_NIST_P384_KEY_SIZE,
 };
 use zeroize::ZeroizeOnDrop;
 
-const MAX_KEY_LEN: usize = 97;
+const MAX_KEY_LEN: usize = ECDSA_ECC_NIST_P384_KEY_SIZE + 1;
 #[derive(ZeroizeOnDrop)]
 struct MbedTlsDheExchangeStruct {
     data_size: usize,
@@ -217,7 +217,7 @@ impl SpdmDheKeyExchange for SpdmDheKeyExchangeP384 {
         let peer_pub_key = MbedTlsDheExchangeStruct::from(&peer_pub_key);
         let mut final_key = SpdmDheFinalKeyStruct::default();
         unsafe {
-            let mut final_key_size = SPDM_MAX_DHE_KEY_SIZE;
+            let mut final_key_size = MAX_KEY_LEN;
             let res = spdm_ecdh_compute_shared_p384(
                 self.0.key.as_ptr(),
                 self.0.key_len,


### PR DESCRIPTION
Fix: #595
The C interface should not use SpdmDheExchangeStruct to store exchange key. Output size from mbedtls may larger than the max size of SpdmDheExchangeStruct.

Fix: #558 
Zero keys. 
