### PR TITLE
Remove unused secret callback, Ref: #624

### DIFF
--- a/fuzz-target/fuzzlib/src/secret.rs
+++ b/fuzz-target/fuzzlib/src/secret.rs
@@ -19,8 +19,6 @@ use spdmlib::secret::*;
 pub static SECRET_IMPL_INSTANCE: SpdmSecret = SpdmSecret {
     spdm_measurement_collection_cb: spdm_measurement_collection_impl,
     spdm_generate_measurement_summary_hash_cb: spdm_generate_measurement_summary_hash_impl,
-    spdm_requester_data_sign_cb: spdm_requester_data_sign_impl,
-    spdm_responder_data_sign_cb: spdm_responder_data_sign_impl,
     spdm_psk_handshake_secret_hkdf_expand_cb: spdm_psk_handshake_secret_hkdf_expand_impl,
     spdm_psk_master_secret_hkdf_expand_cb: spdm_psk_master_secret_hkdf_expand_impl,
 };

--- a/spdmlib/src/secret/mod.rs
+++ b/spdmlib/src/secret/mod.rs
@@ -31,24 +31,6 @@ static UNIMPLETEMTED: SpdmSecret = SpdmSecret {
          _measurement_summary_hash_type: SpdmMeasurementSummaryHashType|
          -> Option<SpdmDigestStruct> { unimplemented!() },
 
-    spdm_requester_data_sign_cb: |_spdm_version: SpdmVersion,
-                                  _op_code: u8,
-                                  _req_base_asym_alg: SpdmReqAsymAlgo,
-                                  _base_hash_algo: SpdmBaseHashAlgo,
-                                  _is_data_hash: bool,
-                                  _message: &[u8],
-                                  _message_size: u8|
-     -> Option<SpdmSignatureStruct> { unimplemented!() },
-
-    spdm_responder_data_sign_cb: |_spdm_version: SpdmVersion,
-                                  _op_code: u8,
-                                  _req_base_asym_alg: SpdmReqAsymAlgo,
-                                  _base_hash_algo: SpdmBaseHashAlgo,
-                                  _is_data_hash: bool,
-                                  _message: &[u8],
-                                  _message_size: u8|
-     -> Option<SpdmSignatureStruct> { unimplemented!() },
-
     spdm_psk_handshake_secret_hkdf_expand_cb: |_spdm_version: SpdmVersion,
                                                _base_hash_algo: SpdmBaseHashAlgo,
                                                _psk_hint: &[u8],
@@ -115,52 +97,6 @@ pub fn spdm_generate_measurement_summary_hash(
         measurement_specification,
         measurement_hash_algo,
         measurement_summary_hash_type,
-    )
-}
-
-pub fn spdm_requester_data_sign(
-    spdm_version: SpdmVersion,
-    op_code: u8,
-    req_base_asym_alg: SpdmReqAsymAlgo,
-    base_hash_algo: SpdmBaseHashAlgo,
-    is_data_hash: bool,
-    message: &[u8],
-    message_size: u8,
-) -> Option<SpdmSignatureStruct> {
-    (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED.clone())
-        .ok()?
-        .spdm_requester_data_sign_cb)(
-        spdm_version,
-        op_code,
-        req_base_asym_alg,
-        base_hash_algo,
-        is_data_hash,
-        message,
-        message_size,
-    )
-}
-
-pub fn spdm_responder_data_sign(
-    spdm_version: SpdmVersion,
-    op_code: u8,
-    req_base_asym_alg: SpdmReqAsymAlgo,
-    base_hash_algo: SpdmBaseHashAlgo,
-    is_data_hash: bool,
-    message: &[u8],
-    message_size: u8,
-) -> Option<SpdmSignatureStruct> {
-    (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED.clone())
-        .ok()?
-        .spdm_responder_data_sign_cb)(
-        spdm_version,
-        op_code,
-        req_base_asym_alg,
-        base_hash_algo,
-        is_data_hash,
-        message,
-        message_size,
     )
 }
 

--- a/spdmlib/src/secret/secret_callback.rs
+++ b/spdmlib/src/secret/secret_callback.rs
@@ -5,7 +5,7 @@
 use crate::protocol::{
     SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmDigestStruct, SpdmHKDFKeyStruct,
     SpdmMeasurementRecordStructure, SpdmMeasurementSpecification, SpdmMeasurementSummaryHashType,
-    SpdmReqAsymAlgo, SpdmSignatureStruct, SpdmVersion,
+    SpdmSignatureStruct, SpdmVersion,
 };
 
 type SpdmMeasurementCollectionCbType = fn(
@@ -23,24 +23,6 @@ type SpdmGenerateMeasurementSummaryHashCbType = fn(
     measurement_summary_hash_type: SpdmMeasurementSummaryHashType,
 ) -> Option<SpdmDigestStruct>;
 
-type SpdmRequesterDataSignCbType = fn(
-    spdm_version: SpdmVersion,
-    op_code: u8,
-    req_base_asym_alg: SpdmReqAsymAlgo,
-    base_hash_algo: SpdmBaseHashAlgo,
-    is_data_hash: bool,
-    message: &[u8],
-    message_size: u8,
-) -> Option<SpdmSignatureStruct>;
-type SpdmResponderDataSignCbType = fn(
-    spdm_version: SpdmVersion,
-    op_code: u8,
-    req_base_asym_alg: SpdmReqAsymAlgo,
-    base_hash_algo: SpdmBaseHashAlgo,
-    is_data_hash: bool,
-    message: &[u8],
-    message_size: u8,
-) -> Option<SpdmSignatureStruct>;
 type SpdmPskHandshakeSecretHkdfExpandCbType = fn(
     spdm_version: SpdmVersion,
     base_hash_algo: SpdmBaseHashAlgo,
@@ -63,10 +45,6 @@ pub struct SpdmSecret {
     pub spdm_measurement_collection_cb: SpdmMeasurementCollectionCbType,
 
     pub spdm_generate_measurement_summary_hash_cb: SpdmGenerateMeasurementSummaryHashCbType,
-
-    pub spdm_requester_data_sign_cb: SpdmRequesterDataSignCbType,
-
-    pub spdm_responder_data_sign_cb: SpdmResponderDataSignCbType,
 
     pub spdm_psk_handshake_secret_hkdf_expand_cb: SpdmPskHandshakeSecretHkdfExpandCbType,
 

--- a/test/spdm-emu/src/secret_impl_sample.rs
+++ b/test/spdm-emu/src/secret_impl_sample.rs
@@ -13,16 +13,13 @@ use spdmlib::message::*;
 use spdmlib::protocol::*;
 use spdmlib::protocol::{
     SpdmBaseHashAlgo, SpdmDigestStruct, SpdmHKDFKeyStruct, SpdmMeasurementRecordStructure,
-    SpdmMeasurementSpecification, SpdmMeasurementSummaryHashType, SpdmReqAsymAlgo,
-    SpdmSignatureStruct,
+    SpdmMeasurementSpecification, SpdmMeasurementSummaryHashType,
 };
 use spdmlib::secret::*;
 
 pub static SECRET_IMPL_INSTANCE: SpdmSecret = SpdmSecret {
     spdm_measurement_collection_cb: spdm_measurement_collection_impl,
     spdm_generate_measurement_summary_hash_cb: spdm_generate_measurement_summary_hash_impl,
-    spdm_requester_data_sign_cb: spdm_requester_data_sign_impl,
-    spdm_responder_data_sign_cb: spdm_responder_data_sign_impl,
     spdm_psk_handshake_secret_hkdf_expand_cb: spdm_psk_handshake_secret_hkdf_expand_impl,
     spdm_psk_master_secret_hkdf_expand_cb: spdm_psk_master_secret_hkdf_expand_impl,
 };
@@ -190,30 +187,6 @@ fn spdm_generate_measurement_summary_hash_impl(
     measurement_summary_hash_type: SpdmMeasurementSummaryHashType,
 ) -> Option<SpdmDigestStruct> {
     Some(SpdmDigestStruct::default())
-}
-
-fn spdm_requester_data_sign_impl(
-    spdm_version: SpdmVersion,
-    op_code: u8,
-    req_base_asym_alg: SpdmReqAsymAlgo,
-    base_hash_algo: SpdmBaseHashAlgo,
-    is_data_hash: bool,
-    message: &[u8],
-    message_size: u8,
-) -> Option<SpdmSignatureStruct> {
-    Some(SpdmSignatureStruct::default())
-}
-
-fn spdm_responder_data_sign_impl(
-    spdm_version: SpdmVersion,
-    op_code: u8,
-    req_base_asym_alg: SpdmReqAsymAlgo,
-    base_hash_algo: SpdmBaseHashAlgo,
-    is_data_hash: bool,
-    message: &[u8],
-    message_size: u8,
-) -> Option<SpdmSignatureStruct> {
-    Some(SpdmSignatureStruct::default())
 }
 
 fn spdm_psk_handshake_secret_hkdf_expand_impl(


### PR DESCRIPTION
SpdmRequesterDataSignCbType and SpdmResponderDataSignCbType are identical and these function definition voilates the sigle responsibilty principle. To implement them need to look for SPDM spec. for example: op_code parameter. This will increase the difficulty to implement the interface

Current spdmlib have already use the SpdmAsymSign interface for signing. The SpdmAsymSign only takes two parameter to determine the private key. Then the implementation for SpdmAsymSign is only need to use (secret_key, data) for sign operation.

Note: There are restrictions to seek secret key. Fix this is not in the current scope.