### PR TITLE
Split SpdmSecret to SpdmSecretPsk and SpdmSecretMeasurement

### DIFF
--- a/fuzz-target/fuzzlib/src/secret.rs
+++ b/fuzz-target/fuzzlib/src/secret.rs
@@ -17,17 +17,17 @@ use spdmlib::protocol::{
 use spdmlib::secret::*;
 
 pub static SECRET_IMPL_INSTANCE: SpdmSecretMeasurement = SpdmSecretMeasurement {
-    spdm_measurement_collection_cb: spdm_measurement_collection_impl,
-    spdm_generate_measurement_summary_hash_cb: spdm_generate_measurement_summary_hash_impl,
+    measurement_collection_cb: measurement_collection_impl,
+    generate_measurement_summary_hash_cb: generate_measurement_summary_hash_impl,
 };
 
 pub static SECRET_PSK_IMPL_INSTANCE: SpdmSecretPsk = SpdmSecretPsk {
-    spdm_psk_handshake_secret_hkdf_expand_cb: spdm_psk_handshake_secret_hkdf_expand_impl,
-    spdm_psk_master_secret_hkdf_expand_cb: spdm_psk_master_secret_hkdf_expand_impl,
+    handshake_secret_hkdf_expand_cb: handshake_secret_hkdf_expand_impl,
+    master_secret_hkdf_expand_cb: master_secret_hkdf_expand_impl,
 };
 
 #[allow(clippy::field_reassign_with_default)]
-fn spdm_measurement_collection_impl(
+fn measurement_collection_impl(
     spdm_version: SpdmVersion,
     measurement_specification: SpdmMeasurementSpecification,
     measurement_hash_algo: SpdmBaseHashAlgo,
@@ -180,7 +180,7 @@ fn spdm_measurement_collection_impl(
     }
 }
 
-fn spdm_generate_measurement_summary_hash_impl(
+fn generate_measurement_summary_hash_impl(
     spdm_version: SpdmVersion,
     base_hash_algo: SpdmBaseHashAlgo,
     measurement_specification: SpdmMeasurementSpecification,
@@ -214,7 +214,7 @@ fn spdm_responder_data_sign_impl(
     Some(SpdmSignatureStruct::default())
 }
 
-fn spdm_psk_handshake_secret_hkdf_expand_impl(
+fn handshake_secret_hkdf_expand_impl(
     spdm_version: SpdmVersion,
     base_hash_algo: SpdmBaseHashAlgo,
     psk_hint: &[u8],
@@ -225,7 +225,7 @@ fn spdm_psk_handshake_secret_hkdf_expand_impl(
     Some(SpdmHKDFKeyStruct::default())
 }
 
-fn spdm_psk_master_secret_hkdf_expand_impl(
+fn master_secret_hkdf_expand_impl(
     spdm_version: SpdmVersion,
     base_hash_algo: SpdmBaseHashAlgo,
     psk_hint: &[u8],

--- a/fuzz-target/fuzzlib/src/secret.rs
+++ b/fuzz-target/fuzzlib/src/secret.rs
@@ -16,9 +16,12 @@ use spdmlib::protocol::{
 };
 use spdmlib::secret::*;
 
-pub static SECRET_IMPL_INSTANCE: SpdmSecret = SpdmSecret {
+pub static SECRET_IMPL_INSTANCE: SpdmSecretMeasurement = SpdmSecretMeasurement {
     spdm_measurement_collection_cb: spdm_measurement_collection_impl,
     spdm_generate_measurement_summary_hash_cb: spdm_generate_measurement_summary_hash_impl,
+};
+
+pub static SECRET_PSK_IMPL_INSTANCE: SpdmSecretPsk = SpdmSecretPsk {
     spdm_psk_handshake_secret_hkdf_expand_cb: spdm_psk_handshake_secret_hkdf_expand_impl,
     spdm_psk_master_secret_hkdf_expand_cb: spdm_psk_master_secret_hkdf_expand_impl,
 };

--- a/fuzz-target/requester/measurement_req/src/main.rs
+++ b/fuzz-target/requester/measurement_req/src/main.rs
@@ -642,7 +642,8 @@ fn main() {
         .start()
         .unwrap();
 
-    spdmlib::secret::register(fuzzlib::secret::SECRET_IMPL_INSTANCE.clone());
+    spdmlib::secret::measurement::register(fuzzlib::secret::SECRET_IMPL_INSTANCE.clone());
+    spdmlib::secret::psk::register(fuzzlib::secret::SECRET_PSK_IMPL_INSTANCE.clone());
     #[cfg(not(feature = "fuzz"))]
     {
         let args: Vec<String> = std::env::args().collect();

--- a/fuzz-target/responder/measurement_rsp/src/main.rs
+++ b/fuzz-target/responder/measurement_rsp/src/main.rs
@@ -52,7 +52,8 @@ fn main() {
         .start()
         .unwrap();
 
-    spdmlib::secret::register(fuzzlib::secret::SECRET_IMPL_INSTANCE.clone());
+    spdmlib::secret::measurement::register(fuzzlib::secret::SECRET_IMPL_INSTANCE.clone());
+    spdmlib::secret::psk::register(fuzzlib::secret::SECRET_PSK_IMPL_INSTANCE.clone());
     #[cfg(not(feature = "fuzz"))]
     {
         let args: Vec<String> = std::env::args().collect();

--- a/spdmlib/src/responder/measurement_rsp.rs
+++ b/spdmlib/src/responder/measurement_rsp.rs
@@ -19,7 +19,7 @@ use crate::error::SPDM_STATUS_INVALID_PARAMETER;
 use crate::message::*;
 use crate::protocol::*;
 use crate::responder::*;
-use crate::secret::*;
+use crate::secret;
 
 impl<'a> ResponderContext<'a> {
     pub fn handle_spdm_measurement(&mut self, session_id: Option<u32>, bytes: &[u8]) {
@@ -119,7 +119,7 @@ impl<'a> ResponderContext<'a> {
             return;
         }
 
-        let real_measurement_block_count = spdm_measurement_collection(
+        let real_measurement_block_count = secret::measurement::measurement_collection(
             spdm_version_sel,
             measurement_specification_sel,
             base_hash_sel,
@@ -140,7 +140,7 @@ impl<'a> ResponderContext<'a> {
         let measurement_record = if get_measurements.measurement_operation
             == SpdmMeasurementOperation::SpdmMeasurementRequestAll
         {
-            spdm_measurement_collection(
+            secret::measurement::measurement_collection(
                 spdm_version_sel,
                 measurement_specification_sel,
                 base_hash_sel,
@@ -154,7 +154,7 @@ impl<'a> ResponderContext<'a> {
                 self.write_spdm_error(SpdmErrorCode::SpdmErrorInvalidRequest, 0, writer);
                 return;
             }
-            spdm_measurement_collection(
+            secret::measurement::measurement_collection(
                 spdm_version_sel,
                 measurement_specification_sel,
                 base_hash_sel,

--- a/spdmlib/src/secret/mod.rs
+++ b/spdmlib/src/secret/mod.rs
@@ -3,144 +3,165 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 mod secret_callback;
 
-use crate::protocol::*;
 use conquer_once::spin::OnceCell;
-pub use secret_callback::{SpdmAsymSign, SpdmSecret};
+pub use secret_callback::{SpdmAsymSign, SpdmSecretMeasurement, SpdmSecretPsk};
 
-pub static SECRET_INSTANCE: OnceCell<SpdmSecret> = OnceCell::uninit();
+static SECRET_MEASUREMENT_INSTANCE: OnceCell<SpdmSecretMeasurement> = OnceCell::uninit();
+static SECRET_PSK_INSTANCE: OnceCell<SpdmSecretPsk> = OnceCell::uninit();
 static CRYPTO_ASYM_SIGN: OnceCell<SpdmAsymSign> = OnceCell::uninit();
 
-pub fn register(context: SpdmSecret) -> bool {
-    SECRET_INSTANCE.try_init_once(|| context).is_ok()
+pub mod measurement {
+    use super::{SpdmSecretMeasurement, SECRET_MEASUREMENT_INSTANCE};
+    use crate::protocol::*;
+
+    pub fn register(context: SpdmSecretMeasurement) -> bool {
+        SECRET_MEASUREMENT_INSTANCE
+            .try_init_once(|| context)
+            .is_ok()
+    }
+
+    static UNIMPLETEMTED: SpdmSecretMeasurement = SpdmSecretMeasurement {
+        spdm_measurement_collection_cb:
+            |_spdm_version: SpdmVersion,
+             _measurement_specification: SpdmMeasurementSpecification,
+             _measurement_hash_algo: SpdmBaseHashAlgo,
+             _measurement_index: usize|
+             -> Option<SpdmMeasurementRecordStructure> { unimplemented!() },
+
+        spdm_generate_measurement_summary_hash_cb:
+            |_spdm_version: SpdmVersion,
+             _base_hash_algo: SpdmBaseHashAlgo,
+             _measurement_specification: SpdmMeasurementSpecification,
+             _measurement_hash_algo: SpdmBaseHashAlgo,
+             _measurement_summary_hash_type: SpdmMeasurementSummaryHashType|
+             -> Option<SpdmDigestStruct> { unimplemented!() },
+    };
+
+    /*
+        Function to get measurements.
+
+        This function wraps SpdmSecret.spdm_measurement_collection_cb callback
+        Device security lib is responsible for the implementation of SpdmSecret.
+        If SECRET_INSTANCE got no registered, a panic with string "not implemented"
+        will be emit.
+
+        @When measurement_index == SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber
+                A dummy Some(SpdmMeasurementRecordStructure) is returned, with its number_of_blocks
+                field set and all other field reserved.
+        @When measurement_index != SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber
+                A normal Some(SpdmMeasurementRecordStructure) is returned, with all fields valid.
+    */
+    pub fn spdm_measurement_collection(
+        spdm_version: SpdmVersion,
+        measurement_specification: SpdmMeasurementSpecification,
+        measurement_hash_algo: SpdmBaseHashAlgo,
+        measurement_index: usize,
+    ) -> Option<SpdmMeasurementRecordStructure> {
+        (SECRET_MEASUREMENT_INSTANCE
+            .try_get_or_init(|| UNIMPLETEMTED.clone())
+            .ok()?
+            .spdm_measurement_collection_cb)(
+            spdm_version,
+            measurement_specification,
+            measurement_hash_algo,
+            measurement_index,
+        )
+    }
+    pub fn spdm_generate_measurement_summary_hash(
+        spdm_version: SpdmVersion,
+        base_hash_algo: SpdmBaseHashAlgo,
+        measurement_specification: SpdmMeasurementSpecification,
+        measurement_hash_algo: SpdmBaseHashAlgo,
+        measurement_summary_hash_type: SpdmMeasurementSummaryHashType,
+    ) -> Option<SpdmDigestStruct> {
+        (SECRET_MEASUREMENT_INSTANCE
+            .try_get_or_init(|| UNIMPLETEMTED.clone())
+            .ok()?
+            .spdm_generate_measurement_summary_hash_cb)(
+            spdm_version,
+            base_hash_algo,
+            measurement_specification,
+            measurement_hash_algo,
+            measurement_summary_hash_type,
+        )
+    }
+}
+pub mod psk {
+    use super::{SpdmSecretPsk, SECRET_PSK_INSTANCE};
+    use crate::protocol::*;
+    pub fn register(context: SpdmSecretPsk) -> bool {
+        SECRET_PSK_INSTANCE.try_init_once(|| context).is_ok()
+    }
+
+    static UNIMPLETEMTED: SpdmSecretPsk = SpdmSecretPsk {
+        spdm_psk_handshake_secret_hkdf_expand_cb: |_spdm_version: SpdmVersion,
+                                                   _base_hash_algo: SpdmBaseHashAlgo,
+                                                   _psk_hint: &[u8],
+                                                   _psk_hint_size: Option<usize>,
+                                                   _info: Option<&[u8]>,
+                                                   _info_size: Option<usize>|
+         -> Option<SpdmHKDFKeyStruct> {
+            unimplemented!()
+        },
+
+        spdm_psk_master_secret_hkdf_expand_cb: |_spdm_version: SpdmVersion,
+                                                _base_hash_algo: SpdmBaseHashAlgo,
+                                                _psk_hint: &[u8],
+                                                _psk_hint_size: Option<usize>,
+                                                _info: Option<&[u8]>,
+                                                _info_size: Option<usize>|
+         -> Option<SpdmHKDFKeyStruct> {
+            unimplemented!()
+        },
+    };
+
+    pub fn spdm_psk_handshake_secret_hkdf_expand(
+        spdm_version: SpdmVersion,
+        base_hash_algo: SpdmBaseHashAlgo,
+        psk_hint: &[u8],
+        psk_hint_size: Option<usize>,
+        info: Option<&[u8]>,
+        info_size: Option<usize>,
+    ) -> Option<SpdmHKDFKeyStruct> {
+        (SECRET_PSK_INSTANCE
+            .try_get_or_init(|| UNIMPLETEMTED.clone())
+            .ok()?
+            .spdm_psk_handshake_secret_hkdf_expand_cb)(
+            spdm_version,
+            base_hash_algo,
+            psk_hint,
+            psk_hint_size,
+            info,
+            info_size,
+        )
+    }
+
+    pub fn spdm_psk_master_secret_hkdf_expand(
+        spdm_version: SpdmVersion,
+        base_hash_algo: SpdmBaseHashAlgo,
+        psk_hint: &[u8],
+        psk_hint_size: Option<usize>,
+        info: Option<&[u8]>,
+        info_size: Option<usize>,
+    ) -> Option<SpdmHKDFKeyStruct> {
+        (SECRET_PSK_INSTANCE
+            .try_get_or_init(|| UNIMPLETEMTED.clone())
+            .ok()?
+            .spdm_psk_master_secret_hkdf_expand_cb)(
+            spdm_version,
+            base_hash_algo,
+            psk_hint,
+            psk_hint_size,
+            info,
+            info_size,
+        )
+    }
 }
 
-static UNIMPLETEMTED: SpdmSecret = SpdmSecret {
-    spdm_measurement_collection_cb: |_spdm_version: SpdmVersion,
-                                     _measurement_specification: SpdmMeasurementSpecification,
-                                     _measurement_hash_algo: SpdmBaseHashAlgo,
-                                     _measurement_index: usize|
-     -> Option<SpdmMeasurementRecordStructure> {
-        unimplemented!()
-    },
-
-    spdm_generate_measurement_summary_hash_cb:
-        |_spdm_version: SpdmVersion,
-         _base_hash_algo: SpdmBaseHashAlgo,
-         _measurement_specification: SpdmMeasurementSpecification,
-         _measurement_hash_algo: SpdmBaseHashAlgo,
-         _measurement_summary_hash_type: SpdmMeasurementSummaryHashType|
-         -> Option<SpdmDigestStruct> { unimplemented!() },
-
-    spdm_psk_handshake_secret_hkdf_expand_cb: |_spdm_version: SpdmVersion,
-                                               _base_hash_algo: SpdmBaseHashAlgo,
-                                               _psk_hint: &[u8],
-                                               _psk_hint_size: Option<usize>,
-                                               _info: Option<&[u8]>,
-                                               _info_size: Option<usize>|
-     -> Option<SpdmHKDFKeyStruct> {
-        unimplemented!()
-    },
-
-    spdm_psk_master_secret_hkdf_expand_cb: |_spdm_version: SpdmVersion,
-                                            _base_hash_algo: SpdmBaseHashAlgo,
-                                            _psk_hint: &[u8],
-                                            _psk_hint_size: Option<usize>,
-                                            _info: Option<&[u8]>,
-                                            _info_size: Option<usize>|
-     -> Option<SpdmHKDFKeyStruct> { unimplemented!() },
-};
-
-/*
-    Function to get measurements.
-
-    This function wraps SpdmSecret.spdm_measurement_collection_cb callback
-    Device security lib is responsible for the implementation of SpdmSecret.
-    If SECRET_INSTANCE got no registered, a panic with string "not implemented"
-    will be emit.
-
-    @When measurement_index == SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber
-            A dummy Some(SpdmMeasurementRecordStructure) is returned, with its number_of_blocks
-            field set and all other field reserved.
-    @When measurement_index != SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber
-            A normal Some(SpdmMeasurementRecordStructure) is returned, with all fields valid.
-*/
-pub fn spdm_measurement_collection(
-    spdm_version: SpdmVersion,
-    measurement_specification: SpdmMeasurementSpecification,
-    measurement_hash_algo: SpdmBaseHashAlgo,
-    measurement_index: usize,
-) -> Option<SpdmMeasurementRecordStructure> {
-    (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED.clone())
-        .ok()?
-        .spdm_measurement_collection_cb)(
-        spdm_version,
-        measurement_specification,
-        measurement_hash_algo,
-        measurement_index,
-    )
-}
-
-pub fn spdm_generate_measurement_summary_hash(
-    spdm_version: SpdmVersion,
-    base_hash_algo: SpdmBaseHashAlgo,
-    measurement_specification: SpdmMeasurementSpecification,
-    measurement_hash_algo: SpdmBaseHashAlgo,
-    measurement_summary_hash_type: SpdmMeasurementSummaryHashType,
-) -> Option<SpdmDigestStruct> {
-    (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED.clone())
-        .ok()?
-        .spdm_generate_measurement_summary_hash_cb)(
-        spdm_version,
-        base_hash_algo,
-        measurement_specification,
-        measurement_hash_algo,
-        measurement_summary_hash_type,
-    )
-}
-
-pub fn spdm_psk_handshake_secret_hkdf_expand(
-    spdm_version: SpdmVersion,
-    base_hash_algo: SpdmBaseHashAlgo,
-    psk_hint: &[u8],
-    psk_hint_size: Option<usize>,
-    info: Option<&[u8]>,
-    info_size: Option<usize>,
-) -> Option<SpdmHKDFKeyStruct> {
-    (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED.clone())
-        .ok()?
-        .spdm_psk_handshake_secret_hkdf_expand_cb)(
-        spdm_version,
-        base_hash_algo,
-        psk_hint,
-        psk_hint_size,
-        info,
-        info_size,
-    )
-}
-
-pub fn spdm_psk_master_secret_hkdf_expand(
-    spdm_version: SpdmVersion,
-    base_hash_algo: SpdmBaseHashAlgo,
-    psk_hint: &[u8],
-    psk_hint_size: Option<usize>,
-    info: Option<&[u8]>,
-    info_size: Option<usize>,
-) -> Option<SpdmHKDFKeyStruct> {
-    (SECRET_INSTANCE
-        .try_get_or_init(|| UNIMPLETEMTED.clone())
-        .ok()?
-        .spdm_psk_master_secret_hkdf_expand_cb)(
-        spdm_version,
-        base_hash_algo,
-        psk_hint,
-        psk_hint_size,
-        info,
-        info_size,
-    )
-}
+pub use measurement::spdm_generate_measurement_summary_hash;
+pub use measurement::spdm_measurement_collection;
+pub use psk::spdm_psk_handshake_secret_hkdf_expand;
+pub use psk::spdm_psk_master_secret_hkdf_expand;
 
 pub mod asym_sign {
     use super::CRYPTO_ASYM_SIGN;

--- a/spdmlib/src/secret/mod.rs
+++ b/spdmlib/src/secret/mod.rs
@@ -4,11 +4,11 @@
 mod secret_callback;
 
 use conquer_once::spin::OnceCell;
-pub use secret_callback::{SpdmAsymSign, SpdmSecretMeasurement, SpdmSecretPsk};
+pub use secret_callback::{SpdmSecretAsymSign, SpdmSecretMeasurement, SpdmSecretPsk};
 
 static SECRET_MEASUREMENT_INSTANCE: OnceCell<SpdmSecretMeasurement> = OnceCell::uninit();
 static SECRET_PSK_INSTANCE: OnceCell<SpdmSecretPsk> = OnceCell::uninit();
-static CRYPTO_ASYM_SIGN: OnceCell<SpdmAsymSign> = OnceCell::uninit();
+static CRYPTO_ASYM_SIGN: OnceCell<SpdmSecretAsymSign> = OnceCell::uninit();
 
 pub mod measurement {
     use super::{SpdmSecretMeasurement, SECRET_MEASUREMENT_INSTANCE};
@@ -21,14 +21,15 @@ pub mod measurement {
     }
 
     static UNIMPLETEMTED: SpdmSecretMeasurement = SpdmSecretMeasurement {
-        spdm_measurement_collection_cb:
-            |_spdm_version: SpdmVersion,
-             _measurement_specification: SpdmMeasurementSpecification,
-             _measurement_hash_algo: SpdmBaseHashAlgo,
-             _measurement_index: usize|
-             -> Option<SpdmMeasurementRecordStructure> { unimplemented!() },
+        measurement_collection_cb: |_spdm_version: SpdmVersion,
+                                    _measurement_specification: SpdmMeasurementSpecification,
+                                    _measurement_hash_algo: SpdmBaseHashAlgo,
+                                    _measurement_index: usize|
+         -> Option<SpdmMeasurementRecordStructure> {
+            unimplemented!()
+        },
 
-        spdm_generate_measurement_summary_hash_cb:
+        generate_measurement_summary_hash_cb:
             |_spdm_version: SpdmVersion,
              _base_hash_algo: SpdmBaseHashAlgo,
              _measurement_specification: SpdmMeasurementSpecification,
@@ -40,7 +41,7 @@ pub mod measurement {
     /*
         Function to get measurements.
 
-        This function wraps SpdmSecret.spdm_measurement_collection_cb callback
+        This function wraps SpdmSecret.measurement_collection_cb callback
         Device security lib is responsible for the implementation of SpdmSecret.
         If SECRET_INSTANCE got no registered, a panic with string "not implemented"
         will be emit.
@@ -51,7 +52,7 @@ pub mod measurement {
         @When measurement_index != SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber
                 A normal Some(SpdmMeasurementRecordStructure) is returned, with all fields valid.
     */
-    pub fn spdm_measurement_collection(
+    pub fn measurement_collection(
         spdm_version: SpdmVersion,
         measurement_specification: SpdmMeasurementSpecification,
         measurement_hash_algo: SpdmBaseHashAlgo,
@@ -60,14 +61,14 @@ pub mod measurement {
         (SECRET_MEASUREMENT_INSTANCE
             .try_get_or_init(|| UNIMPLETEMTED.clone())
             .ok()?
-            .spdm_measurement_collection_cb)(
+            .measurement_collection_cb)(
             spdm_version,
             measurement_specification,
             measurement_hash_algo,
             measurement_index,
         )
     }
-    pub fn spdm_generate_measurement_summary_hash(
+    pub fn generate_measurement_summary_hash(
         spdm_version: SpdmVersion,
         base_hash_algo: SpdmBaseHashAlgo,
         measurement_specification: SpdmMeasurementSpecification,
@@ -77,7 +78,7 @@ pub mod measurement {
         (SECRET_MEASUREMENT_INSTANCE
             .try_get_or_init(|| UNIMPLETEMTED.clone())
             .ok()?
-            .spdm_generate_measurement_summary_hash_cb)(
+            .generate_measurement_summary_hash_cb)(
             spdm_version,
             base_hash_algo,
             measurement_specification,
@@ -94,28 +95,24 @@ pub mod psk {
     }
 
     static UNIMPLETEMTED: SpdmSecretPsk = SpdmSecretPsk {
-        spdm_psk_handshake_secret_hkdf_expand_cb: |_spdm_version: SpdmVersion,
-                                                   _base_hash_algo: SpdmBaseHashAlgo,
-                                                   _psk_hint: &[u8],
-                                                   _psk_hint_size: Option<usize>,
-                                                   _info: Option<&[u8]>,
-                                                   _info_size: Option<usize>|
-         -> Option<SpdmHKDFKeyStruct> {
-            unimplemented!()
-        },
+        handshake_secret_hkdf_expand_cb: |_spdm_version: SpdmVersion,
+                                          _base_hash_algo: SpdmBaseHashAlgo,
+                                          _psk_hint: &[u8],
+                                          _psk_hint_size: Option<usize>,
+                                          _info: Option<&[u8]>,
+                                          _info_size: Option<usize>|
+         -> Option<SpdmHKDFKeyStruct> { unimplemented!() },
 
-        spdm_psk_master_secret_hkdf_expand_cb: |_spdm_version: SpdmVersion,
-                                                _base_hash_algo: SpdmBaseHashAlgo,
-                                                _psk_hint: &[u8],
-                                                _psk_hint_size: Option<usize>,
-                                                _info: Option<&[u8]>,
-                                                _info_size: Option<usize>|
-         -> Option<SpdmHKDFKeyStruct> {
-            unimplemented!()
-        },
+        master_secret_hkdf_expand_cb: |_spdm_version: SpdmVersion,
+                                       _base_hash_algo: SpdmBaseHashAlgo,
+                                       _psk_hint: &[u8],
+                                       _psk_hint_size: Option<usize>,
+                                       _info: Option<&[u8]>,
+                                       _info_size: Option<usize>|
+         -> Option<SpdmHKDFKeyStruct> { unimplemented!() },
     };
 
-    pub fn spdm_psk_handshake_secret_hkdf_expand(
+    pub fn handshake_secret_hkdf_expand(
         spdm_version: SpdmVersion,
         base_hash_algo: SpdmBaseHashAlgo,
         psk_hint: &[u8],
@@ -126,7 +123,7 @@ pub mod psk {
         (SECRET_PSK_INSTANCE
             .try_get_or_init(|| UNIMPLETEMTED.clone())
             .ok()?
-            .spdm_psk_handshake_secret_hkdf_expand_cb)(
+            .handshake_secret_hkdf_expand_cb)(
             spdm_version,
             base_hash_algo,
             psk_hint,
@@ -136,7 +133,7 @@ pub mod psk {
         )
     }
 
-    pub fn spdm_psk_master_secret_hkdf_expand(
+    pub fn master_secret_hkdf_expand(
         spdm_version: SpdmVersion,
         base_hash_algo: SpdmBaseHashAlgo,
         psk_hint: &[u8],
@@ -147,7 +144,7 @@ pub mod psk {
         (SECRET_PSK_INSTANCE
             .try_get_or_init(|| UNIMPLETEMTED.clone())
             .ok()?
-            .spdm_psk_master_secret_hkdf_expand_cb)(
+            .master_secret_hkdf_expand_cb)(
             spdm_version,
             base_hash_algo,
             psk_hint,
@@ -158,21 +155,16 @@ pub mod psk {
     }
 }
 
-pub use measurement::spdm_generate_measurement_summary_hash;
-pub use measurement::spdm_measurement_collection;
-pub use psk::spdm_psk_handshake_secret_hkdf_expand;
-pub use psk::spdm_psk_master_secret_hkdf_expand;
-
 pub mod asym_sign {
     use super::CRYPTO_ASYM_SIGN;
     use crate::protocol::{SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmSignatureStruct};
-    use crate::secret::SpdmAsymSign;
+    use crate::secret::SpdmSecretAsymSign;
 
-    pub fn register(context: SpdmAsymSign) -> bool {
+    pub fn register(context: SpdmSecretAsymSign) -> bool {
         CRYPTO_ASYM_SIGN.try_init_once(|| context).is_ok()
     }
 
-    static DEFAULT: SpdmAsymSign = SpdmAsymSign {
+    static DEFAULT: SpdmSecretAsymSign = SpdmSecretAsymSign {
         sign_cb: |_base_hash_algo: SpdmBaseHashAlgo,
                   _base_asym_algo: SpdmBaseAsymAlgo,
                   _data: &[u8]|

--- a/spdmlib/src/secret/secret_callback.rs
+++ b/spdmlib/src/secret/secret_callback.rs
@@ -42,20 +42,20 @@ type SpdmPskMasterSecretHkdfExpandCbType = fn(
 
 #[derive(Clone)]
 pub struct SpdmSecretMeasurement {
-    pub spdm_measurement_collection_cb: SpdmMeasurementCollectionCbType,
+    pub measurement_collection_cb: SpdmMeasurementCollectionCbType,
 
-    pub spdm_generate_measurement_summary_hash_cb: SpdmGenerateMeasurementSummaryHashCbType,
+    pub generate_measurement_summary_hash_cb: SpdmGenerateMeasurementSummaryHashCbType,
 }
 
 #[derive(Clone)]
 pub struct SpdmSecretPsk {
-    pub spdm_psk_handshake_secret_hkdf_expand_cb: SpdmPskHandshakeSecretHkdfExpandCbType,
+    pub handshake_secret_hkdf_expand_cb: SpdmPskHandshakeSecretHkdfExpandCbType,
 
-    pub spdm_psk_master_secret_hkdf_expand_cb: SpdmPskMasterSecretHkdfExpandCbType,
+    pub master_secret_hkdf_expand_cb: SpdmPskMasterSecretHkdfExpandCbType,
 }
 
 #[derive(Clone)]
-pub struct SpdmAsymSign {
+pub struct SpdmSecretAsymSign {
     pub sign_cb: fn(
         base_hash_algo: SpdmBaseHashAlgo,
         base_asym_algo: SpdmBaseAsymAlgo,

--- a/spdmlib/src/secret/secret_callback.rs
+++ b/spdmlib/src/secret/secret_callback.rs
@@ -41,11 +41,14 @@ type SpdmPskMasterSecretHkdfExpandCbType = fn(
 ) -> Option<SpdmHKDFKeyStruct>;
 
 #[derive(Clone)]
-pub struct SpdmSecret {
+pub struct SpdmSecretMeasurement {
     pub spdm_measurement_collection_cb: SpdmMeasurementCollectionCbType,
 
     pub spdm_generate_measurement_summary_hash_cb: SpdmGenerateMeasurementSummaryHashCbType,
+}
 
+#[derive(Clone)]
+pub struct SpdmSecretPsk {
     pub spdm_psk_handshake_secret_hkdf_expand_cb: SpdmPskHandshakeSecretHkdfExpandCbType,
 
     pub spdm_psk_master_secret_hkdf_expand_cb: SpdmPskMasterSecretHkdfExpandCbType,

--- a/spdmlib/src/testlib.rs
+++ b/spdmlib/src/testlib.rs
@@ -7,7 +7,7 @@
 use crate::common::*;
 use crate::crypto::{SpdmCryptoRandom, SpdmHmac};
 pub use crate::protocol::*;
-use crate::secret::SpdmAsymSign;
+use crate::secret::SpdmSecretAsymSign;
 use crate::{common, responder};
 
 use crate::error::{
@@ -316,7 +316,7 @@ impl SpdmTransportEncap for PciDoeTransportEncap {
     }
 }
 
-pub static ASYM_SIGN_IMPL: SpdmAsymSign = SpdmAsymSign { sign_cb: asym_sign };
+pub static ASYM_SIGN_IMPL: SpdmSecretAsymSign = SpdmSecretAsymSign { sign_cb: asym_sign };
 
 fn asym_sign(
     base_hash_algo: SpdmBaseHashAlgo,

--- a/spdmlib/tests/common/crypto_callbacks.rs
+++ b/spdmlib/tests/common/crypto_callbacks.rs
@@ -4,7 +4,7 @@
 
 #![allow(unused)]
 
-use spdmlib::secret::SpdmAsymSign;
+use spdmlib::secret::SpdmSecretAsymSign;
 
 use spdmlib::protocol::{
     SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmSignatureStruct, RSAPSS_2048_KEY_SIZE,
@@ -14,7 +14,7 @@ use spdmlib::protocol::{
 
 use super::utils::get_test_key_directory;
 
-pub static ASYM_SIGN_IMPL: SpdmAsymSign = SpdmAsymSign { sign_cb: asym_sign };
+pub static ASYM_SIGN_IMPL: SpdmSecretAsymSign = SpdmSecretAsymSign { sign_cb: asym_sign };
 
 fn asym_sign(
     base_hash_algo: SpdmBaseHashAlgo,

--- a/spdmlib/tests/common/testlib.rs
+++ b/spdmlib/tests/common/testlib.rs
@@ -7,7 +7,7 @@
 use spdmlib::common::*;
 use spdmlib::crypto::{SpdmCryptoRandom, SpdmHmac};
 use spdmlib::protocol::*;
-use spdmlib::secret::SpdmAsymSign;
+use spdmlib::secret::SpdmSecretAsymSign;
 use spdmlib::{common, responder};
 
 use codec::enum_builder;
@@ -306,7 +306,7 @@ impl SpdmTransportEncap for PciDoeTransportEncap {
     }
 }
 
-pub static ASYM_SIGN_IMPL: SpdmAsymSign = SpdmAsymSign { sign_cb: asym_sign };
+pub static ASYM_SIGN_IMPL: SpdmSecretAsymSign = SpdmSecretAsymSign { sign_cb: asym_sign };
 
 fn asym_sign(
     base_hash_algo: SpdmBaseHashAlgo,

--- a/spdmlib_crypto_mbedtls/tests/common/crypto_callbacks.rs
+++ b/spdmlib_crypto_mbedtls/tests/common/crypto_callbacks.rs
@@ -4,7 +4,7 @@
 
 #![allow(unused)]
 
-use spdmlib::secret::SpdmAsymSign;
+use spdmlib::secret::SpdmSecretAsymSign;
 
 use spdmlib::protocol::{
     SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmSignatureStruct, RSAPSS_2048_KEY_SIZE,
@@ -14,7 +14,7 @@ use spdmlib::protocol::{
 
 use super::utils::get_test_key_directory;
 
-pub static ASYM_SIGN_IMPL: SpdmAsymSign = SpdmAsymSign { sign_cb: asym_sign };
+pub static ASYM_SIGN_IMPL: SpdmSecretAsymSign = SpdmSecretAsymSign { sign_cb: asym_sign };
 
 fn asym_sign(
     base_hash_algo: SpdmBaseHashAlgo,

--- a/test/spdm-emu/src/crypto_callback.rs
+++ b/test/spdm-emu/src/crypto_callback.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use spdmlib::secret::SpdmAsymSign;
+use spdmlib::secret::SpdmSecretAsymSign;
 
 use spdmlib::protocol::{
     SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmSignatureStruct, RSAPSS_2048_KEY_SIZE,
@@ -12,7 +12,7 @@ use spdmlib::protocol::{
     RSASSA_4096_KEY_SIZE, SPDM_MAX_ASYM_KEY_SIZE,
 };
 
-pub static ASYM_SIGN_IMPL: SpdmAsymSign = SpdmAsymSign { sign_cb: asym_sign };
+pub static ASYM_SIGN_IMPL: SpdmSecretAsymSign = SpdmSecretAsymSign { sign_cb: asym_sign };
 
 fn asym_sign(
     base_hash_algo: SpdmBaseHashAlgo,

--- a/test/spdm-emu/src/secret_impl_sample.rs
+++ b/test/spdm-emu/src/secret_impl_sample.rs
@@ -18,17 +18,17 @@ use spdmlib::protocol::{
 use spdmlib::secret::*;
 
 pub static SECRET_MEASUREMENT_IMPL_INSTANCE: SpdmSecretMeasurement = SpdmSecretMeasurement {
-    spdm_measurement_collection_cb: spdm_measurement_collection_impl,
-    spdm_generate_measurement_summary_hash_cb: spdm_generate_measurement_summary_hash_impl,
+    measurement_collection_cb: measurement_collection_impl,
+    generate_measurement_summary_hash_cb: generate_measurement_summary_hash_impl,
 };
 
 pub static SECRET_PSK_IMPL_INSTANCE: SpdmSecretPsk = SpdmSecretPsk {
-    spdm_psk_handshake_secret_hkdf_expand_cb: spdm_psk_handshake_secret_hkdf_expand_impl,
-    spdm_psk_master_secret_hkdf_expand_cb: spdm_psk_master_secret_hkdf_expand_impl,
+    handshake_secret_hkdf_expand_cb: handshake_secret_hkdf_expand_impl,
+    master_secret_hkdf_expand_cb: master_secret_hkdf_expand_impl,
 };
 
 #[allow(clippy::field_reassign_with_default)]
-fn spdm_measurement_collection_impl(
+fn measurement_collection_impl(
     spdm_version: SpdmVersion,
     measurement_specification: SpdmMeasurementSpecification,
     measurement_hash_algo: SpdmBaseHashAlgo,
@@ -182,7 +182,7 @@ fn spdm_measurement_collection_impl(
     }
 }
 
-fn spdm_generate_measurement_summary_hash_impl(
+fn generate_measurement_summary_hash_impl(
     spdm_version: SpdmVersion,
     base_hash_algo: SpdmBaseHashAlgo,
     measurement_specification: SpdmMeasurementSpecification,
@@ -192,7 +192,7 @@ fn spdm_generate_measurement_summary_hash_impl(
     Some(SpdmDigestStruct::default())
 }
 
-fn spdm_psk_handshake_secret_hkdf_expand_impl(
+fn handshake_secret_hkdf_expand_impl(
     spdm_version: SpdmVersion,
     base_hash_algo: SpdmBaseHashAlgo,
     psk_hint: &[u8],
@@ -203,7 +203,7 @@ fn spdm_psk_handshake_secret_hkdf_expand_impl(
     Some(SpdmHKDFKeyStruct::default())
 }
 
-fn spdm_psk_master_secret_hkdf_expand_impl(
+fn master_secret_hkdf_expand_impl(
     spdm_version: SpdmVersion,
     base_hash_algo: SpdmBaseHashAlgo,
     psk_hint: &[u8],
@@ -224,11 +224,11 @@ mod tests {
     use spdmlib::secret::*;
 
     #[test]
-    fn test_case0_spdm_measurement_collection() {
+    fn test_case0_measurement_collection() {
         let reg_result = register(SECRET_MEASUREMENT_IMPL_INSTANCE.clone());
         assert_eq!(reg_result, true);
 
-        let records = spdm_measurement_collection(
+        let records = measurement_collection(
             SpdmVersion::SpdmVersion11,
             SpdmMeasurementSpecification::DMTF,
             SpdmBaseHashAlgo::TPM_ALG_SHA_512,

--- a/test/spdm-emu/src/secret_impl_sample.rs
+++ b/test/spdm-emu/src/secret_impl_sample.rs
@@ -17,9 +17,12 @@ use spdmlib::protocol::{
 };
 use spdmlib::secret::*;
 
-pub static SECRET_IMPL_INSTANCE: SpdmSecret = SpdmSecret {
+pub static SECRET_MEASUREMENT_IMPL_INSTANCE: SpdmSecretMeasurement = SpdmSecretMeasurement {
     spdm_measurement_collection_cb: spdm_measurement_collection_impl,
     spdm_generate_measurement_summary_hash_cb: spdm_generate_measurement_summary_hash_impl,
+};
+
+pub static SECRET_PSK_IMPL_INSTANCE: SpdmSecretPsk = SpdmSecretPsk {
     spdm_psk_handshake_secret_hkdf_expand_cb: spdm_psk_handshake_secret_hkdf_expand_impl,
     spdm_psk_master_secret_hkdf_expand_cb: spdm_psk_master_secret_hkdf_expand_impl,
 };
@@ -213,7 +216,7 @@ fn spdm_psk_master_secret_hkdf_expand_impl(
 
 #[cfg(all(test,))]
 mod tests {
-    use super::SECRET_IMPL_INSTANCE;
+    use super::SECRET_MEASUREMENT_IMPL_INSTANCE;
     use codec::Codec;
     use spdmlib::protocol::{
         SpdmBaseHashAlgo, SpdmMeasurementBlockStructure, SpdmMeasurementSpecification, SpdmVersion,
@@ -222,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_case0_spdm_measurement_collection() {
-        let reg_result = register(SECRET_IMPL_INSTANCE.clone());
+        let reg_result = register(SECRET_MEASUREMENT_IMPL_INSTANCE.clone());
         assert_eq!(reg_result, true);
 
         let records = spdm_measurement_collection(

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -23,7 +23,6 @@ use spdm_emu::crypto_callback::ASYM_SIGN_IMPL;
 use spdm_emu::secret_impl_sample::*;
 use spdm_emu::socket_io_transport::SocketIoTransport;
 use spdm_emu::spdm_emu::*;
-use spdmlib::secret::*;
 use spdmlib::{common, config, protocol::*, responder};
 
 fn process_socket_message(
@@ -87,7 +86,7 @@ fn main() {
     #[cfg(feature = "spdm-mbedtls")]
     spdm_emu::crypto::crypto_mbedtls_register_handles();
 
-    register(SECRET_IMPL_INSTANCE.clone());
+    spdmlib::secret::measurement::register(SECRET_MEASUREMENT_IMPL_INSTANCE.clone());
 
     let listener = TcpListener::bind("127.0.0.1:2323").expect("Couldn't bind to the server");
     println!("server start!");


### PR DESCRIPTION
Fix #644 
SpmdSecret -> SpdmSecretMeasurement, SpdmSecretPsk

Usage:
```
SpdmSecretMeasurement
spdmlib::secret::measurement::register
spdmlib:secret::messurement::measurement_collection
spdmlib:secret::messurement::generate_measurement_summary_hash

SpdmSecretPsk
spdmlib::secret::psk::register
spdmlib::secret::psk::handshake_secret_hkdf_expand
spdmlib::secret::psk::master_secret_hkdf_expand

SpdmSecretAsymSign
spdmlib:secret::asym_sign::register
spdmlib:secret::asym_sign::sign
```
