### PR TITLE
update cfg to avoid runtime stack too large.

### DIFF
--- a/spdmlib/etc/config.json
+++ b/spdmlib/etc/config.json
@@ -4,7 +4,7 @@
         "max_cert_chain_data_size": 4096
     },
     "measurement_config": {
-        "max_measurement_record_size": 4096,
+        "max_measurement_record_size": 4000,
         "max_measurement_val_len": 1024
     },
     "psk_config": {
@@ -13,9 +13,9 @@
     },
     "max_session_count": 4,
     "transport_config": {
-        "sender_buffer_size": 4864,
-        "receiver_buffer_size": 4864
+        "sender_buffer_size": 4160,
+        "receiver_buffer_size": 4160
     },
-    "max_spdm_msg_size": 4608,
+    "max_spdm_msg_size": 4096,
     "heartbeat_period_value": 0
 }


### PR DESCRIPTION
max_cert_chain_data_size:
3500: cargo run -p spdm-responder-emu --no-default-features --features "spdm-ring"
4096: cargo run -p spdm-responder-emu --no-default-features --features "spdm-ring,hashed-transcript-data"