### PR TITLE
Fuzz: add missing base_hash_sel

### DIFF
--- a/fuzz-target/requester/key_update_req/src/main.rs
+++ b/fuzz-target/requester/key_update_req/src/main.rs
@@ -29,6 +29,7 @@ fn fuzz_send_receive_spdm_key_update(data: &[u8]) {
             rsp_provision_info,
         );
         responder.common.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion12;
+        responder.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         responder.common.session[0] = SpdmSession::new();
         responder.common.session[0].setup(4294836221).unwrap();
         responder.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);
@@ -49,6 +50,7 @@ fn fuzz_send_receive_spdm_key_update(data: &[u8]) {
             req_provision_info,
         );
         requester.common.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion12;
+        requester.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
         requester.common.session[0] = SpdmSession::new();
         requester.common.session[0].setup(4294836221).unwrap();
         requester.common.session[0].set_session_state(SpdmSessionState::SpdmSessionEstablished);

--- a/fuzz-target/responder/certificate_rsp/src/main.rs
+++ b/fuzz-target/responder/certificate_rsp/src/main.rs
@@ -1,8 +1,11 @@
 // Copyright (c) 2020 Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
-use fuzzlib::{spdmlib::protocol::SpdmVersion, *};
-use spdmlib::common::SpdmConnectionState;
+use fuzzlib::{
+    spdmlib::common::SpdmConnectionState,
+    spdmlib::protocol::{SpdmBaseHashAlgo, SpdmVersion},
+    *,
+};
 
 fn fuzz_handle_spdm_certificate(data: &[u8]) {
     let (config_info, provision_info) = rsp_create_info();
@@ -26,6 +29,7 @@ fn fuzz_handle_spdm_certificate(data: &[u8]) {
     );
 
     context.common.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion12;
+    context.common.negotiate_info.base_hash_sel = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
     context.common.provision_info.my_cert_chain = [
         Some(RSP_CERT_CHAIN_BUFF),
         None,


### PR DESCRIPTION
The provision of `negotiate_info.base_hash_sel` is missing in certificate_rsp fuzz test.  
Add it to pass `append_message_b()`

https://github.com/jyao1/rust-spdm/blob/f4ad2effb00a81c4c130b0a80dcb11b4b3a10716/spdmlib/src/responder/certificate_rsp.rs#L67-L79