### PR TITLE
Check none session after handle_spdm_psk_finish_response

### DIFF
--- a/spdmlib/src/requester/psk_finish_req.rs
+++ b/spdmlib/src/requester/psk_finish_req.rs
@@ -59,11 +59,9 @@ impl<'a> RequesterContext<'a> {
         let receive_used = res.unwrap();
         let res = self.handle_spdm_psk_finish_response(session_id, &receive_buffer[..receive_used]);
         if res.is_err() {
-            let _ = self
-                .common
-                .get_session_via_id(session_id)
-                .unwrap()
-                .teardown(session_id);
+            if let Some(session) = self.common.get_session_via_id(session_id) {
+                let _ = session.teardown(session_id);
+            }
         }
         res
     }


### PR DESCRIPTION
After `handle_spdm_psk_finish_response`, `get_session_via_id` is possible to be none. So we need check none value again before unwarp it.

This is the same issue with #627 but appeared in another place. 