### PR TITLE
[CI/CD] update coverage.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
           profile: minimal
           toolchain: nightly-2022-11-21
           override: true
-          components: rust-src, rustfmt, clippy
+          components: rust-src, rustfmt, clippy, llvm-tools-preview
 
       - name: Run cargo install grcov
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
llvm-tools-preview is missing.
This patch add llvm-tools-preview component
Fix: #693 