### PR TITLE
make MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE public to outside of crate.

### DIFF
--- a/spdmlib/src/message/vendor.rs
+++ b/spdmlib/src/message/vendor.rs
@@ -14,7 +14,7 @@ use conquer_once::spin::OnceCell;
 
 // config::MAX_SPDM_MSG_SIZE - 7 - 2
 // SPDM0274 1.2.1: Table 56, table 57 VENDOR_DEFINED_RESPONSE message format
-pub(crate) const MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE: usize = config::MAX_SPDM_MSG_SIZE - 7 - 2;
+pub const MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE: usize = config::MAX_SPDM_MSG_SIZE - 7 - 2;
 
 pub const MAX_SPDM_VENDOR_DEFINED_VENDOR_ID_LEN: usize = 0xFF;
 


### PR DESCRIPTION
currently, the constant MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE is only visible to spdmlib crate. It should be public to outside of spdmlib crate, because the caller outside of spdmlib may need to create VendorDefinedRspPayloadStruct or VendorDefinedReqPayloadStruct, which contains an array vendor_defined_rsp_payload. And its size should be MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE.